### PR TITLE
Updating scripts 

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,8 +2,8 @@
 from snakemake.io import glob_wildcards
 
 
-configfile: "config/config.yaml"
-#configfile: "scripts/testing/config_test.yaml"
+#configfile: "config/config.yaml"
+configfile: "scripts/testing/config_test_BS.yaml"
 
 
 ROOT = config['dataset']["root_dir"]
@@ -31,8 +31,8 @@ rule all_default:
 rule all_preprocess:
     input:
         expand([
-            (f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{{subject}}/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_preprocessed.snirf"),  #  preprocessed_dataessed snirf
-            (f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{{subject}}/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_dataquality.json"), # data qual sidecar 
+            (f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{{subject}}/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_preprocessed.pkl"),  #  preprocessed_dataessed snirf
+            (f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{{subject}}/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_dataquality_geo.sidecar"), # data qual sidecar 
             ],
             subject = config["dataset"]["subject"],
             task = config["dataset"]["task"],
@@ -44,6 +44,7 @@ rule all_blockaverage:
         expand([
             (f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{{subject}}/sub-{{subject}}_task-{{task}}_nirs_blockaverage.pkl"),  # blockaverage data
             (f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{{subject}}/sub-{{subject}}_task-{{task}}_nirs_dataquality.json"),  # blockaverage dataqual
+            (f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{{subject}}/sub-{{subject}}_task-{{task}}_nirs_geo.sidecar")
             ],
             subject = config["dataset"]["subject"],
             task = config["dataset"]["task"],
@@ -68,8 +69,8 @@ rule preprocess:
         snirf = f"{ROOT}/sub-{{subject}}/nirs/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs.snirf",
         events = f"{ROOT}/sub-{{subject}}/nirs/sub-{{subject}}_task-{{task}}_run-{{run}}_events.tsv"
     output:
-        snirf = (f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{{subject}}/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_preprocessed.snirf"), # preprocessed snirf
-        sidecar = (f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{{subject}}/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_dataquality.json"), # data qual sidecar
+        snirf = (f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{{subject}}/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_preprocessed.pkl"), # preprocessed snirf
+        sidecar = (f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{{subject}}/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_dataquality_geo.sidecar"), # data qual sidecar
         
         # !!! figure out how to get these updated with each run of rule
         #dqr_plot = (f"{ROOT}/derivatives/{DERIV}/plots/DQR/sub-{{subject}}_task-{{task}}_run-{{run}}_nirs_DQR.png"),   # DQR plots
@@ -86,7 +87,6 @@ rule preprocess:
     #log:
         #"logs/preprocess/sub-{subject}_task-{task}_run-{run}_nirs_preprocessed.log"   # empty bc have to use shell and not script
     script:
-        #"scripts/test.py"
         "scripts/preprocess.py"
 
 
@@ -96,13 +96,13 @@ def all_preprocessed_runs(wc):
     
     run_paths =  [
         f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{wc.subject}/"
-        f"sub-{wc.subject}_task-{wc.task}_run-{run}_nirs_preprocessed.snirf"
+        f"sub-{wc.subject}_task-{wc.task}_run-{run}_nirs_preprocessed.pkl"
         for run in config["dataset"]["run"]
     ]
     
     data_quality_paths = [
         f"{ROOT}/derivatives/{DERIV}/preprocessed_data/sub-{wc.subject}/"
-        f"sub-{wc.subject}_task-{wc.task}_run-{run}_nirs_dataquality.json"
+        f"sub-{wc.subject}_task-{wc.task}_run-{run}_nirs_dataquality_geo.sidecar"
         for run in config["dataset"]["run"]
     ]
     
@@ -121,7 +121,8 @@ rule blockaverage:
     output:
         # block averaged data containing HRF for each task
         pickle = (f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{{subject}}/sub-{{subject}}_task-{{task}}_nirs_blockaverage.pkl"),
-        json = (f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{{subject}}/sub-{{subject}}_task-{{task}}_nirs_dataquality.json")
+        json = (f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{{subject}}/sub-{{subject}}_task-{{task}}_nirs_dataquality.json"),
+        geo = (f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{{subject}}/sub-{{subject}}_task-{{task}}_nirs_geo.sidecar")
     params:
         cfg_blockaverage = config['blockaverage'],
         cfg_dataset = config['dataset'],
@@ -148,6 +149,11 @@ def all_blockaverage_files(wc):
         for subject in config["dataset"]["subject"]
     ]
     
+    geo_paths = [
+        f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{subject}/sub-{subject}_task-{wc.task}_nirs_geo.sidecar"
+        for subject in config["dataset"]["subject"]
+    ]
+    
     #blockavg_nc_paths = [
      #   f"{ROOT}/derivatives/{DERIV}/blockaverage/sub-{subject}/sub-{subject}_task-{wc.task}_nirs_blockaverage.nc"
       #  for subject in config["dataset"]["subject"]
@@ -162,6 +168,7 @@ def all_blockaverage_files(wc):
     return {
         "blockavg":  blockavg_paths,
         "quality":  data_quality_paths, 
+        "geo": geo_paths
         #"blockavg_nc": blockavg_nc_paths, 
         #"epochs_nc": epoch_nc_paths
     }
@@ -171,7 +178,9 @@ def all_blockaverage_files(wc):
 rule groupaverage:
     input: 
         blockavg_subs  = lambda wc: all_blockaverage_files(wc)["blockavg"], # block avg data
-        quality  = lambda wc: all_blockaverage_files(wc)["quality"]    # quality metrics
+        quality  = lambda wc: all_blockaverage_files(wc)["quality"],    # quality metrics
+        geo  = lambda wc: all_blockaverage_files(wc)["geo"]    # geometric pos and landmarks
+        
         #blockavg_nc  = lambda wc: all_blockaverage_files(wc)["blockavg_nc"]    # blockaverage data net cdf
         #epochs_nc  = lambda wc: all_blockaverage_files(wc)["epochs_nc"]  # epochs data net cdf
     output:

--- a/workflow/config/config.yaml
+++ b/workflow/config/config.yaml
@@ -42,7 +42,7 @@ preprocess:
       enable: true
 
     imu_glm:       # FOR WALKING DATA
-      enable: false
+      enable: true
       statesPerDataFrame: 89
       hWin: [-3, 5, 1]   # will be put into np.arange func UPDATE THAT
       n_components: [3, 2]  # [gyro, accel] 
@@ -93,7 +93,7 @@ groupaverage:
    blockaverage_val: "0 micromolar**2"
   mse_od:
    mse_val_for_bad_data: 1e1
-   mse_min_thresh: 1e-3 #1e-6
+   mse_min_thresh: 1e-6
    blockaverage_val: 0
    
    
@@ -111,7 +111,7 @@ image_recon:
     threshold_scalp: "5 mm"
     sigma_brain: "1 mm"
     sigma_scalp: "5 mm"
-  t_win: [4, 7]
+  t_win: [10, 20]
   probe_dir: "/projectnb/nphfnirs/ns/Shannon/Data/probes/NN22_WHHD/12NN/"
   snirf_name_probe: "fullhead_56x144_NN22_System1.snirf"
   head_model: 'ICBM152'

--- a/workflow/scripts/groupaverage.py
+++ b/workflow/scripts/groupaverage.py
@@ -30,7 +30,7 @@ import pdb
 #%%
 
 
-def groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, flag_prune_channels, blockavg_files, data_quality_files, out):
+def groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, flag_prune_channels, blockavg_files, data_quality_files, geo_files, out):
     print("group averaging: \n")
     print(blockavg_files)
     
@@ -55,296 +55,106 @@ def groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, 
     cfg_mse['mse_amp_thresh'] = min(mse_amp_thresh) # get minimum amplitude threshold
                             
     
-    # Loop over subjects
-    blockaverage_subj = None
-    for subj_idx, subj in enumerate(blockavg_files):
-        # Load in json data qual
-        with open(data_quality_files[subj_idx], 'r') as fp:
-            data_quality_sub = json.load(fp)
-        idx_amp = np.array(data_quality_sub['idx_amp'])
-        idx_sat = np.array(data_quality_sub['idx_sat'])
-        bad_chans_sat = np.array(data_quality_sub['bad_chans_sat'])
-        bad_chans_amp = np.array(data_quality_sub['bad_chans_amp'])
+    # # # 
+    
         
-        # Load in current sub's blockaverage file
-        with open(subj, 'rb') as f:
-            rec_blockavg = pickle.load(f)
-        blockaverage = rec_blockavg['blockaverage']
-        epochs_all = rec_blockavg['epochs']
-        
-        # Load in net cdf files
-        #blockaverage2 = xr.load_dataarray(blockavg_files_nc)
-        #epochs2 = xr.load_dataarray(epoch_files_nc)
-        
-        blockaverage_weighted = blockaverage.copy()
-        
-        n_epochs = len(epochs_all.epoch)
-        n_chs = len(epochs_all.channel)
-
-        mse_t_lst = []
-        
-    # # Loop thru trial tpes
+    # Loop thru trial tpes
   
-    # for idxt, trial_type in enumerate(cfg_hrf['stim_lst']): 
+    for idxt, trial_type in enumerate(cfg_hrf['stim_lst']): 
+
+        # Loop over subjects
+        blockaverage_subj = None
+        for subj_idx, subj in enumerate(blockavg_files):
+            # Load in json data qual
+            with open(data_quality_files[subj_idx], 'r') as fp:
+                data_quality_sub = json.load(fp)
+            idx_amp = np.array(data_quality_sub['idx_amp'])
+            idx_sat = np.array(data_quality_sub['idx_sat'])
+            bad_chans_sat = np.array(data_quality_sub['bad_chans_sat'])
+            bad_chans_amp = np.array(data_quality_sub['bad_chans_amp'])
+            
+            # Load in current sub's blockaverage file
+            with open(subj, 'rb') as f:
+                results = pickle.load(f)
+            blockaverage = results['blockaverage']
+            epochs = results['epochs']
         
-    #     blockaverage_subj = None
-
-    #     # Loop over subjects
-    #     blockaverage_subj = None
-    #     for subj_idx, subj in enumerate(blockavg_files):
-    #         # Load in json data qual
-    #         with open(data_quality_files[subj_idx], 'r') as fp:
-    #             data_quality_sub = json.load(fp)
-    #         idx_amp = np.array(data_quality_sub['bad_chans_amp'])
-    #         idx_sat = np.array(data_quality_sub['bad_chans_sat'])
-            
-    #         # Load in current sub's blockaverage file
-    #         with open(subj, 'rb') as f:
-    #             rec_blockavg = pickle.load(f)
-    #         blockaverage = rec_blockavg['blockaverage']
-    #         epochs_all = rec_blockavg['epochs']
-            
-    #         # Load in net cdf files
-    #         #blockaverage2 = xr.load_dataarray(blockavg_files_nc)
-    #         #epochs2 = xr.load_dataarray(epoch_files_nc)
-            
-    #         blockaverage_weighted = blockaverage.copy()
-            
-    #         n_epochs = len(epochs_all.epoch)
-    #         n_chs = len(epochs_all.channel)
-
-    #         mse_t_lst = []            
-
-            
-    #         # baseline correct and then get the block average across all epochs and runs for that subject
-    #         baseline = epochs_all.sel(reltime=(epochs_all.reltime < 0)).mean('reltime')
-    #         epochs = epochs_all - baseline
-    #         blockaverage = epochs.groupby('trial_type').mean('epoch')
-            
-    #         blockaverage_weighted = blockaverage.copy()
-    #         n_epochs = len(epochs.epoch)
-    #         n_chs = len(epochs.channel)
-            
-            
-    #         # de-mean the epochs
-    #         epochs_zeromean = epochs - blockaverage
-        
-    #         if 'chromo' in blockaverage.dims:
-    #             epochs_zeromean = epochs_zeromean.stack(measurement=['channel','chromo']).sortby('chromo')
-    #             blockaverage = blockaverage.transpose('trial_type', 'channel', 'chromo', 'reltime')
-    #             blockaverage_weighted = blockaverage_weighted.transpose('trial_type', 'channel', 'chromo', 'reltime')
-
-    #         else:
-    #             epochs_zeromean = epochs_zeromean.stack(measurement=['channel','wavelength']).sortby('wavelength')
-    #             blockaverage = blockaverage.transpose('trial_type', 'channel', 'wavelength', 'reltime')
-    #             blockaverage_weighted = blockaverage_weighted.transpose('trial_type', 'channel', 'wavelength', 'reltime')
-
-    #         epochs_zeromean = epochs_zeromean.transpose('trial_type', 'measurement', 'reltime', 'epoch')            
-            
-    #         mse_t = (epochs_zeromean**2).sum('epoch') / (n_epochs - 1)**2 # this is squared to get variance of the mean, aka MSE of the mean
-
-    #         # set bad values in mse_t to the bad value threshold
-    #         idx_bad = np.where(mse_t == 0)[0]
-    #         idx_bad1 = idx_bad[idx_bad<n_chs]
-    #         idx_bad2 = idx_bad[idx_bad>=n_chs] - n_chs
-            
-    #         mse_t[:,idx_amp,:] = cfg_mse['mse_val_for_bad_data']
-    #         mse_t[:,idx_amp+n_chs,:] = cfg_mse['mse_val_for_bad_data']
-    #         mse_t[:,idx_sat,:] = cfg_mse['mse_val_for_bad_data']
-    #         mse_t[:,idx_sat+n_chs,:] = cfg_mse['mse_val_for_bad_data']
-    #         mse_t[:,idx_bad,:] = cfg_mse['mse_val_for_bad_data']
-            
-    #         channels = blockaverage_weighted.channel
-    #         blockaverage_weighted.loc[trial_type, channels.isel(channel=idx_amp),:,:] = cfg_mse['blockaverage_val']
-    #         blockaverage_weighted.loc[trial_type, channels.isel(channel=idx_sat),:,:] = cfg_mse['blockaverage_val']
-    #         blockaverage_weighted.loc[trial_type, channels.isel(channel=idx_bad1),:,:] = cfg_mse['blockaverage_val']
-    #         blockaverage_weighted.loc[trial_type, channels.isel(channel=idx_bad2),:,:] = cfg_mse['blockaverage_val']
-            
-
-    #         blockaverage.loc[trial_type, channels.isel(channel=idx_amp),:,:] = cfg_mse['blockaverage_val']
-    #         blockaverage.loc[trial_type, channels.isel(channel=idx_sat),:,:] = cfg_mse['blockaverage_val']
-    #         blockaverage.loc[trial_type, channels.isel(channel=idx_bad1),:,:] = cfg_mse['blockaverage_val']
-    #         blockaverage.loc[trial_type, channels.isel(channel=idx_bad2),:,:] = cfg_mse['blockaverage_val']
-            
-    #         # set the minimum value of mse_t
-    #         if 'chromo' in epochs.dims:
-    #             mse_t = mse_t.unstack('measurement').transpose('trial_type', 'chromo','channel','reltime')
-    #         else:
-    #             mse_t = mse_t.unstack('measurement').transpose('trial_type','channel','wavelength','reltime')
-
-    #         source_coord = blockaverage_weighted['source']
-    #         mse_t = mse_t.assign_coords(source=('channel',source_coord.data))
-    #         detector_coord = blockaverage_weighted['detector']
-    #         mse_t = mse_t.assign_coords(detector=('channel',detector_coord.data))
-            
-    #         # mse_t = xr.where(mse_t < cfg_mse['mse_min_thresh'], cfg_mse['mse_min_thresh'], mse_t)
-
-    #         # gather the blockaverage across subjects
-    #         if blockaverage_subj is None:
-                                
-    #             blockaverage_subj_weighted = blockaverage_weighted / mse_t
-
-    #             blockaverage_mean_weighted = blockaverage_weighted / mse_t
-    #             sum_mse_inv = 1/mse_t
-                
-    #             # add a subject dimension and coordinate
-    #             blockaverage_subj = blockaverage.expand_dims('subj')
-    #             blockaverage_subj = blockaverage_subj.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
-     
-    #             mse_subj = mse_t.expand_dims('subj') 
-    #             mse_subj = mse_subj.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
-                
-    #         else:
-                                
-    #             blockaverage_subj_weighted = xr.concat([blockaverage_subj_weighted, blockaverage_weighted / mse_t], dim='subj')
-                
-    #             blockaverage_mean_weighted = blockaverage_mean_weighted + blockaverage_weighted  / mse_t
-    #             sum_mse_inv = sum_mse_inv + 1 / mse_t
-                
-    #             blockaverage_tmp = blockaverage.expand_dims('subj')
-    #             blockaverage_tmp = blockaverage_tmp.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
-
-    #             blockaverage_subj = xr.concat([blockaverage_subj, blockaverage_tmp], dim='subj')
-    
-    #             mse_subj_tmp = mse_t.expand_dims('subj')
-    #             mse_subj_tmp = mse_subj_tmp.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
-
-    #             mse_subj = xr.concat([mse_subj, mse_subj_tmp], dim='subj')
-    
-            
-    #     # DONE LOOP OVER SUBJECTS
-            
-    #     # get the unweighted average
-    #     blockaverage_mean = blockaverage_subj.mean('subj')
-    
-    #     # get the mean mse within subjects
-    #     mse_mean_within_subject = 1 / sum_mse_inv
-        
-    #     blockaverage_mean_weighted = blockaverage_mean_weighted / sum_mse_inv
-
-    #     mse_weighted_between_subjects_tmp = (blockaverage_subj - blockaverage_mean_weighted)**2 / mse_subj
-    #     mse_weighted_between_subjects = mse_weighted_between_subjects_tmp.mean('subj')
-    #     mse_weighted_between_subjects = mse_weighted_between_subjects * mse_mean_within_subject # normalized by the within subject variances as weights
-     
-    #     # get the weighted average
-    #     mse_btw_within_sum_subj = mse_subj + mse_weighted_between_subjects
-    #     denom = (1/mse_btw_within_sum_subj).sum('subj')
-        
-    #     blockaverage_mean_weighted = (blockaverage_subj / mse_btw_within_sum_subj).sum('subj')
-    #     blockaverage_mean_weighted = blockaverage_mean_weighted / denom
-        
-    #     mse_total = 1/denom
-        
-    #     total_stderr_blockaverage = np.sqrt( mse_total )
-    #     total_stderr_blockaverage = total_stderr_blockaverage.assign_coords(trial_type=blockaverage_mean_weighted.trial_type)
-
-    #     if all_trial_blockaverage_mean is None:
-            
-    #         all_trial_blockaverage_mean = blockaverage_mean
-    #         all_trial_blockaverage_weighted_mean = blockaverage_mean_weighted
-    #         all_trial_total_stderr = total_stderr_blockaverage
-            
-    #         all_trial_blockaverage_subj = blockaverage_subj
-    #         all_trial_blockaverage_weighted_subj = blockaverage_subj_weighted
-    #         all_trial_mse_subj = mse_subj 
-            
-    #     else:
-
-    #         all_trial_blockaverage_mean = xr.concat([all_trial_blockaverage_mean, blockaverage_mean], dim='trial_type')
-    #         all_trial_blockaverage_weighted_mean = xr.concat([all_trial_blockaverage_weighted_mean, blockaverage_mean_weighted], dim='trial_type')
-    #         all_trial_total_stderr = xr.concat([all_trial_total_stderr, total_stderr_blockaverage], dim='trial_type')
-            
-    #         all_trial_blockaverage_subj = xr.concat([all_trial_blockaverage_subj, blockaverage_subj], dim='trial_type') # !!! this is causing mult trial types?
-    #         all_trial_blockaverage_weighted_subj = xr.concat([all_trial_blockaverage_weighted_subj, blockaverage_subj_weighted], dim='trial_type')
-    #         all_trial_mse_subj = xr.concat([all_trial_mse_subj, mse_subj], dim='trial_type')
-    # # DONE LOOP OVER TRIAL_TYPES
-    
-    
-    # # !!! Do we want these plots still? Would need to also load in a rec ???  - or just load in saved geo2d and geo3d?
-    # # # Plot scalp plot of mean, tstat,rsme + Plot mse hist
-    # # for idxt, trial_type in enumerate(blockaverage_mean_weighted.trial_type.values):         
-    # #     plot_mean_stderr(rec, rec_str, trial_type, cfg_dataset, cfg_blockavg, blockaverage_mean_weighted, 
-    # #                      total_stderr_blockaverage, mse_mean_within_subject, mse_weighted_between_subjects)
-    # #     plot_mse_hist(rec, rec_str, trial_type, cfg_dataset, blockaverage_mse_subj, cfg_blockavg['mse_val_for_bad_data'], cfg_blockavg['mse_min_thresh'])  # !!! not sure if these r working correctly tbh
-    
-    
-    # blockaverage_mean, blockaverage_weighted_mean, total_stderr, blockaverage_subj, blockaverage_weighted_subj, mse_subj
-    
-    # groupavg_results = {'group_blockaverage': all_trial_blockaverage_mean,              # weighted group avg 
-    #                'group_blockaverage_weighted': all_trial_blockaverage_weighted_mean,   # unweighted group aaverage
-    #                'total_stderr_blockaverage': all_trial_total_stderr,
-    #                'blockaverage_subj': all_trial_blockaverage_subj,  # always unweighted   - load into img recon
-    #                'blockaverage_mse_subj': all_trial_mse_subj, # - load into img recon
-    #                'blockaverage_weighted_subj': all_trial_blockaverage_weighted_subj,
-    #                #'geo2d' : rec[0][0].geo2d,
-    #                #'geo3d' : rec[0][0].geo3d  # !!! save 2d and 3d pts in blockaverage????
-    #            }
-    
-    # # Save data a pickle for now  # !!! Change to snirf in future when its debugged
-    # with open(out, "wb") as f:        # if output is a single string, it wraps it in an output object and need to index in
-    #     pickle.dump(groupavg_results, f, protocol=pickle.HIGHEST_PROTOCOL)
-        
-    # print("Group average data saved successfully")
-    
-    
-    #return all_trial_blockaverage_mean, all_trial_blockaverage_weighted_mean, all_trial_total_stderr, all_trial_blockaverage_subj, all_trial_blockaverage_weighted_subj, all_trial_mse_subj
-       
-        # Loop thru trial tpes
-      
-        for idxt, trial_type in enumerate(cfg_hrf['stim_lst']): 
-            
-            epochs_zeromean = epochs_all.where(epochs_all.trial_type == trial_type, drop=True) - blockaverage_weighted.sel(trial_type=trial_type) # zero mean data
-    
-            if 'chromo' in blockaverage.dims:
-                foo_t = epochs_zeromean.stack(measurement=['channel','chromo']).sortby('chromo')
-            else:
-                foo_t = epochs_zeromean.stack(measurement=['channel','wavelength']).sortby('wavelength')
             #pdb.set_trace()
-            foo_t = foo_t.transpose('measurement', 'reltime', 'epoch')  # !!! this does not have trial type?
-            mse_t = (foo_t**2).sum('epoch') / (n_epochs - 1)**2 # this is squared to get variance of the mean, aka MSE of the mean
+            epochs = epochs.where(epochs.trial_type == trial_type, drop=True)
+            blockaverage1 = blockaverage.sel(trial_type=trial_type)  # select current trial type
+            blockaverage1 = blockaverage1.expand_dims('trial_type')  # readd trial type coord
+            blockaverage = blockaverage1.copy()
             
-            # ^ this gets the variance  across epochs
+            # Load geometric positions and landmarks # !!! don't need to do for each subject in reality, but for snakemake yes?
+            with gzip.open(geo_files[subj_idx], 'rb') as f:
+                geo_pos = pickle.load(f)
+            geo2d = geo_pos['geo2d']
+            geo3d = geo_pos['geo3d']
+          
+            # Load in net cdf files
+            #blockaverage2 = xr.load_dataarray(blockavg_files_nc)
+            #epochs2 = xr.load_dataarray(epoch_files_nc)
             
+            #pdb.set_trace()
             
-            # # get the variance, correctig channels we don't trust (saturated, low amp, low var) 
-            # mse_t = quality.measurement_variance( # this gets the measurement variance across time ... only good for timeseries
-            #         foo_t,
-            #         list_bad_channels = None, #idx_bad_channels,  # !!! where to get this?  -- before this was where mse_t = 0
-            #         bad_rel_var = 1e6, # If bad_abs_var is none then it uses this value relative to maximum variance
-            #         bad_abs_var = None, #cfg_blockavg['cfg_mse_conc']['mse_val_for_bad_data'],
-            #         calc_covariance = False
-            #     )
-            
-            # mse_t = blockaverage_weighted + cfg_mse['mse_min_thresh'] # set a small value to avoid dominance for low variance channels
-            # blockaverage_weighted.loc[dict(channel=blockaverage_weighted.isel(channel=idx_amp).channel.data)] = cfg_mse['blockaverage_val']
-            # blockaverage_weighted.loc[dict(channel=blockaverage_weighted.isel(channel=idx_sat).channel.data)] = cfg_mse['blockaverage_val']
-    
-            # !!! maybe have the above func have a helper func that is called variance_clean  
-    
-            # Set bad values in mse_t to the bad value threshold
-            bad_mask = mse_t.data == 0
-            bad_any = bad_mask.any(axis=1)
-            bad_chans_mse = mse_t.channel[bad_any].values
-            # bad_chans_mse = set(mse_t.channel[bad_any].values)
+            blockaverage_weighted = blockaverage.copy()
+            n_epochs = len(epochs.epoch)
+            n_chs = len(epochs.channel)
 
+            mse_t_lst = []            
+            
+            #pdb.set_trace()
+            # de-mean the epochs
+            epochs_zeromean = epochs - blockaverage  # !!! CHANGE TO SEL TRIAL TYPE
+        
+            if 'chromo' in blockaverage.dims:
+                epochs_zeromean = epochs_zeromean.stack(measurement=['channel','chromo']).sortby('chromo')
+                blockaverage = blockaverage.transpose('trial_type', 'channel', 'chromo', 'reltime')
+                blockaverage_weighted = blockaverage_weighted.transpose('trial_type', 'channel', 'chromo', 'reltime')
+
+            else:
+                epochs_zeromean = epochs_zeromean.stack(measurement=['channel','wavelength']).sortby('wavelength')
+                blockaverage = blockaverage.transpose('trial_type', 'channel', 'wavelength', 'reltime')
+                blockaverage_weighted = blockaverage_weighted.transpose('trial_type', 'channel', 'wavelength', 'reltime')
+
+            epochs_zeromean = epochs_zeromean.transpose('trial_type', 'measurement', 'reltime', 'epoch')            
+            
+            mse_t = (epochs_zeromean**2).sum('epoch') / (n_epochs - 1)**2 # this is squared to get variance of the mean, aka MSE of the mean
+
+            #pdb.set_trace()
+            
+            # set bad values in mse_t to the bad value threshold
             # idx_bad = np.where(mse_t == 0)[0]
             # idx_bad1 = idx_bad[idx_bad<n_chs]
             # idx_bad2 = idx_bad[idx_bad>=n_chs] - n_chs
             
-            # mse_t[idx_amp,:] = cfg_mse['mse_val_for_bad_data']
-            # mse_t[idx_amp+n_chs,:] = cfg_mse['mse_val_for_bad_data']
-            # mse_t[idx_sat,:] = cfg_mse['mse_val_for_bad_data']
-            # mse_t[idx_sat+n_chs,:] = cfg_mse['mse_val_for_bad_data']
-         
-            # mse_t.loc[dict(channel=bad_chans_amp)] = cfg_mse['mse_val_for_bad_data']
-            # mse_t.loc[dict(channel=bad_chans_sat)] = cfg_mse['mse_val_for_bad_data']
-            mse_t[mse_t.channel.isin(bad_chans_amp), :] = cfg_mse['mse_val_for_bad_data']
-            mse_t[mse_t.channel.isin(bad_chans_sat), :] = cfg_mse['mse_val_for_bad_data']
-            mse_t[mse_t.channel.isin(bad_chans_mse), :] = cfg_mse['mse_val_for_bad_data']
-            # mse_t[idx_bad] = cfg_mse['mse_val_for_bad_data']
-            # mse_t.loc[dict(channel=bad_chans_mse)] = cfg_mse['mse_val_for_bad_data']
+            bad_mask = mse_t.sel(trial_type=trial_type).data == 0
+            bad_any = bad_mask.any(axis=1)
+            # pdb.set_trace()
+            bad_chans_mse = mse_t.channel[bad_any].values
             
-            channels = blockaverage_weighted.channel
+            # mse_t[:,idx_amp,:] = cfg_mse['mse_val_for_bad_data']
+            # mse_t[:,idx_amp+n_chs,:] = cfg_mse['mse_val_for_bad_data']
+            # mse_t[:,idx_sat,:] = cfg_mse['mse_val_for_bad_data']
+            # mse_t[:,idx_sat+n_chs,:] = cfg_mse['mse_val_for_bad_data']
+            # mse_t[:,idx_bad,:] = cfg_mse['mse_val_for_bad_data']
+            
+            # channels = blockaverage_weighted.channel
+            # blockaverage_weighted.loc[trial_type, channels.isel(channel=idx_amp),:,:] = cfg_mse['blockaverage_val']
+            # blockaverage_weighted.loc[trial_type, channels.isel(channel=idx_sat),:,:] = cfg_mse['blockaverage_val']
+            # blockaverage_weighted.loc[trial_type, channels.isel(channel=idx_bad1),:,:] = cfg_mse['blockaverage_val']
+            # blockaverage_weighted.loc[trial_type, channels.isel(channel=idx_bad2),:,:] = cfg_mse['blockaverage_val']
+            
+            # pdb.set_trace()
+            # blockaverage.loc[trial_type, channels.isel(channel=idx_amp),:,:] = cfg_mse['blockaverage_val']
+            # blockaverage.loc[trial_type, channels.isel(channel=idx_sat),:,:] = cfg_mse['blockaverage_val']
+            # blockaverage.loc[trial_type, channels.isel(channel=idx_bad1),:,:] = cfg_mse['blockaverage_val']
+            # blockaverage.loc[trial_type, channels.isel(channel=idx_bad2),:,:] = cfg_mse['blockaverage_val']
+            
+            mse_t[:, mse_t.channel.isin(bad_chans_amp), :] = cfg_mse['mse_val_for_bad_data']
+            mse_t[:, mse_t.channel.isin(bad_chans_sat), :] = cfg_mse['mse_val_for_bad_data']
+            mse_t[:, mse_t.channel.isin(bad_chans_mse), :] = cfg_mse['mse_val_for_bad_data']
+            
             blockaverage_weighted.loc[dict(trial_type=trial_type, channel=bad_chans_sat)] = cfg_mse['blockaverage_val']
             blockaverage_weighted.loc[dict(trial_type=trial_type, channel=bad_chans_amp)] = cfg_mse['blockaverage_val']
             blockaverage_weighted.loc[dict(trial_type=trial_type, channel=bad_chans_mse)] = cfg_mse['blockaverage_val']
@@ -356,103 +166,127 @@ def groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, 
             #blockaverage.loc[dict(trial_type=trial_type, channel=bad_chans_mse)] = cfg_mse['blockaverage_val']
     
     
-            # !!! DO we still wanna do this?
             # set the minimum value of mse_t
-            #mse_t = xr.where(mse_t < cfg_mse['mse_min_thresh'], cfg_mse['mse_min_thresh'], mse_t)
-            
-            if 'chromo' in blockaverage.dims:
-                mse_t = mse_t.unstack('measurement').transpose('chromo','channel','reltime')  
+            if 'chromo' in epochs.dims:
+                mse_t = mse_t.unstack('measurement').transpose('trial_type', 'chromo','channel','reltime')
             else:
-                mse_t = mse_t.unstack('measurement').transpose('wavelength','channel','reltime')  # !!! xrutils.other_dim
-                
-            mse_t = mse_t.expand_dims('trial_type')
+                mse_t = mse_t.unstack('measurement').transpose('trial_type','channel','wavelength','reltime')
+
             source_coord = blockaverage_weighted['source']
             mse_t = mse_t.assign_coords(source=('channel',source_coord.data))
             detector_coord = blockaverage_weighted['detector']
             mse_t = mse_t.assign_coords(detector=('channel',detector_coord.data))
             
+            mse_t = xr.where(mse_t < cfg_mse['mse_min_thresh'], cfg_mse['mse_min_thresh'], mse_t)  # !!! maybe can be removed when we have the between subject mse
+
+            # gather the blockaverage across subjects
+            if blockaverage_subj is None:
+                                
+                blockaverage_subj_weighted = blockaverage_weighted / mse_t 
+
+                blockaverage_mean_weighted = blockaverage_weighted / mse_t
+                sum_mse_inv = 1/mse_t
+                
+                # add a subject dimension and coordinate
+                blockaverage_subj = blockaverage.expand_dims('subj')
+                blockaverage_subj = blockaverage_subj.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
+     
+                mse_subj = mse_t.expand_dims('subj') 
+                mse_subj = mse_subj.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
+                
+            else:
+                                
+                blockaverage_subj_weighted = xr.concat([blockaverage_subj_weighted, blockaverage_weighted / mse_t], dim='subj')
+                
+                blockaverage_mean_weighted = blockaverage_mean_weighted + blockaverage_weighted  / mse_t
+                sum_mse_inv = sum_mse_inv + 1 / mse_t
+                
+                blockaverage_tmp = blockaverage.expand_dims('subj')
+                blockaverage_tmp = blockaverage_tmp.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
+
+                blockaverage_subj = xr.concat([blockaverage_subj, blockaverage_tmp], dim='subj')
+    
+                mse_subj_tmp = mse_t.expand_dims('subj')
+                mse_subj_tmp = mse_subj_tmp.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
+
+                mse_subj = xr.concat([mse_subj, mse_subj_tmp], dim='subj')
+    
             
-            mse_t = mse_t.assign_coords(trial_type = [trial_type]) # assign coords to match curr trial type
-            mse_t_lst.append(mse_t) # append mse_t for curr trial type to list
-
-            # DONE LOOP OVER TRIAL TYPES
-            
-        mse_t_tmp = xr.concat(mse_t_lst, dim='trial_type') # concat the 2 trial types
-        mse_t = mse_t_tmp # reassign the newly appended mse_t with both trial types to mse_t 
-
-        
-        # gather the blockaverage across subjects
-        if blockaverage_subj is None: 
-            # add a subject dimension and coordinate
-            blockaverage_subj = blockaverage.expand_dims('subj')
-            blockaverage_subj = blockaverage_subj.assign_coords(subj=[cfg_dataset['subject'][subj_idx]]) # !!! will need to update when exluding subs
-
-            blockaverage_mse_subj = mse_t.expand_dims('subj') # mse of blockaverage for each sub
-            blockaverage_mse_subj = blockaverage_mse_subj.assign_coords(subj=[cfg_dataset['subject'][subj_idx]]) # !!! does snakemake give list of files in order of sub list?
-            
-            blockaverage_mean_weighted = blockaverage_weighted / mse_t
-
-            blockaverage_mse_inv_mean_weighted = 1 / mse_t
-            
-        else:   
-            #blockaverage_subj_tmp = blockaverage_weighted
-            blockaverage_subj_tmp = blockaverage.expand_dims('subj')
-            blockaverage_subj_tmp = blockaverage_subj_tmp.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
-            blockaverage_subj = xr.concat([blockaverage_subj, blockaverage_subj_tmp], dim='subj')
-
-            blockaverage_mse_subj_tmp = mse_t.expand_dims('subj')
-            
-            blockaverage_mse_subj_tmp = blockaverage_mse_subj_tmp.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
-            blockaverage_mse_subj = xr.concat([blockaverage_mse_subj, blockaverage_mse_subj_tmp], dim='subj') # !!! this does not have trial types
-
-            blockaverage_mean_weighted = blockaverage_mean_weighted +  blockaverage_weighted / mse_t
-            blockaverage_mse_inv_mean_weighted = blockaverage_mse_inv_mean_weighted + 1/mse_t 
-        
         # DONE LOOP OVER SUBJECTS
+            
+        # get the unweighted average
+        blockaverage_mean = blockaverage_subj.mean('subj')
+    
+        # get the mean mse within subjects
+        mse_mean_within_subject = 1 / sum_mse_inv
         
-    # get the unweighted average
-    blockaverage_mean = blockaverage_subj.mean('subj')
-    
-    # get the weighted average  (old)
-    #blockaverage_mean_weighted = blockaverage_mean_weighted / blockaverage_mse_inv_mean_weighted
-    
-    # get the mean mse within subjects
-    mse_mean_within_subject = 1 / blockaverage_mse_inv_mean_weighted
+        blockaverage_mean_weighted = blockaverage_mean_weighted / sum_mse_inv
 
-    # get the mse between subjects
-    mse_weighted_between_subjects_tmp = (blockaverage_subj - blockaverage_mean_weighted)**2 / blockaverage_mse_subj   # was -blockaverage_mean_weighted
-    mse_weighted_between_subjects = mse_weighted_between_subjects_tmp.mean('subj')
-    mse_weighted_between_subjects = mse_weighted_between_subjects * mse_mean_within_subject  # normalized by the within subject variances as weights
- 
-    # get the weighted average
-    mse_btw_within_sum_subj = blockaverage_mse_subj + mse_weighted_between_subjects
-    denom = (1/mse_btw_within_sum_subj).sum('subj')
+        mse_weighted_between_subjects_tmp = (blockaverage_subj - blockaverage_mean_weighted)**2 / mse_subj
+        mse_weighted_between_subjects = mse_weighted_between_subjects_tmp.mean('subj')
+        mse_weighted_between_subjects = mse_weighted_between_subjects * mse_mean_within_subject # normalized by the within subject variances as weights
+     
+        # get the weighted average
+        mse_btw_within_sum_subj = mse_subj + mse_weighted_between_subjects
+        denom = (1/mse_btw_within_sum_subj).sum('subj')
+        
+        blockaverage_mean_weighted = (blockaverage_subj / mse_btw_within_sum_subj).sum('subj')
+        blockaverage_mean_weighted = blockaverage_mean_weighted / denom
+        
+        mse_total = 1/denom
+        
+        total_stderr_blockaverage = np.sqrt( mse_total )
+        total_stderr_blockaverage = total_stderr_blockaverage.assign_coords(trial_type=blockaverage_mean_weighted.trial_type)
+        
+        #pdb.set_trace()
+        if all_trial_blockaverage_mean is None:
+            
+            all_trial_blockaverage_mean = blockaverage_mean
+            all_trial_blockaverage_weighted_mean = blockaverage_mean_weighted
+            all_trial_total_stderr = total_stderr_blockaverage
+            
+            all_trial_blockaverage_subj = blockaverage_subj
+            all_trial_blockaverage_weighted_subj = blockaverage_subj_weighted
+            all_trial_mse_subj = mse_subj 
+            
+        else:
+
+            all_trial_blockaverage_mean = xr.concat([all_trial_blockaverage_mean, blockaverage_mean], dim='trial_type')
+            all_trial_blockaverage_weighted_mean = xr.concat([all_trial_blockaverage_weighted_mean, blockaverage_mean_weighted], dim='trial_type')
+            all_trial_total_stderr = xr.concat([all_trial_total_stderr, total_stderr_blockaverage], dim='trial_type')
+            
+            all_trial_blockaverage_subj = xr.concat([all_trial_blockaverage_subj, blockaverage_subj], dim='trial_type') 
+            all_trial_blockaverage_weighted_subj = xr.concat([all_trial_blockaverage_weighted_subj, blockaverage_subj_weighted], dim='trial_type')
+            all_trial_mse_subj = xr.concat([all_trial_mse_subj, mse_subj], dim='trial_type')
+            
+            
+    # DONE LOOP OVER TRIAL_TYPES
     
-    blockaverage_mean_weighted = (blockaverage_subj / mse_btw_within_sum_subj).sum('subj') # !!! reassinging blockaverage_mean_weighted
-    blockaverage_mean_weighted = blockaverage_mean_weighted / denom
     
-    mse_total = 1/denom
+    # !!! need to add funcs to a module or at the end of this script lawl
+    # !!! Do we want these plots still? Would need to also load in a rec ???  - or just load in saved geo2d and geo3d?
+    # Plot scalp plot of mean, tstat,rsme + Plot mse hist
+    rec_test = cedalion.io.read_snirf("/projectnb/nphfnirs/ns/Shannon/Data/Interactive_Walking_HD/sub-01/nirs/sub-01_task-STS_run-01_nirs.snirf")
     
-    total_stderr_blockaverage = np.sqrt( mse_total )
-    total_stderr_blockaverage = total_stderr_blockaverage.assign_coords(trial_type=blockaverage_mean_weighted.trial_type)
-    
-    
-    
-    # # !!! Do we want these plots still? Would need to also load in a rec ???  - or just load in saved geo2d and geo3d?
-    # # # Plot scalp plot of mean, tstat,rsme + Plot mse hist
-    # # for idxt, trial_type in enumerate(blockaverage_mean_weighted.trial_type.values):         
-    # #     plot_mean_stderr(rec, rec_str, trial_type, cfg_dataset, cfg_blockavg, blockaverage_mean_weighted, 
-    # #                      total_stderr_blockaverage, mse_mean_within_subject, mse_weighted_between_subjects)
-    # #     plot_mse_hist(rec, rec_str, trial_type, cfg_dataset, blockaverage_mse_subj, cfg_blockavg['mse_val_for_bad_data'], cfg_blockavg['mse_min_thresh'])  # !!! not sure if these r working correctly tbh
+    #pdb.set_trace()
+    for idxt, trial_type in enumerate(all_trial_blockaverage_weighted_mean.trial_type.values):         
+        plot_mean_stderr(rec_test[0], 'amp', trial_type, cfg_dataset, cfg_blockaverage, blockaverage_mean_weighted, 
+                         all_trial_total_stderr, mse_mean_within_subject, mse_weighted_between_subjects, geo3d)
+        
+        plot_mse_hist(rec_test[0], 'amp', trial_type, cfg_dataset, all_trial_mse_subj, cfg_mse['mse_val_for_bad_data'], cfg_mse['mse_min_thresh'])  # !!! not sure if these r working correctly tbh
     
     
-    groupavg_results = {'group_blockaverage_weighted': blockaverage_mean_weighted, # weighted group avg   
-                'group_blockaverage': blockaverage_mean,  # unweighted group aaverage
-               'total_stderr_blockaverage': total_stderr_blockaverage,
-               'blockaverage_subj': blockaverage_subj,  # always unweighted   - load into img recon
-               'blockaverage_mse_subj': blockaverage_mse_subj, # - load into img recon
-               # 'geo2d' : rec.geo2d,
-               # 'geo3d' : rec.geo3d     # !!! save 2d and 3d pts in blockaverage????
+    #blockaverage_mean, blockaverage_weighted_mean, total_stderr, blockaverage_subj, blockaverage_weighted_subj, mse_subj
+    
+    #pdb.set_trace()
+    groupavg_results = {'group_blockaverage': all_trial_blockaverage_mean,              # weighted group avg 
+                   'group_blockaverage_weighted': all_trial_blockaverage_weighted_mean,   # unweighted group aaverage
+                   'total_stderr_blockaverage': all_trial_total_stderr,
+                   'blockaverage_subj': all_trial_blockaverage_subj,  # always unweighted   - load into img recon
+                   'blockaverage_mse_subj': all_trial_mse_subj, # - load into img recon
+                   'blockaverage_weighted_subj': all_trial_blockaverage_weighted_subj,
+                   'geo2d' : geo2d,
+                   'geo3d' : geo3d,
                }
     
     # Save data a pickle for now  # !!! Change to snirf in future when its debugged
@@ -461,7 +295,435 @@ def groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, 
         
     print("Group average data saved successfully")
     
-# #%%
+    
+    #return all_trial_blockaverage_mean, all_trial_blockaverage_weighted_mean, all_trial_total_stderr, all_trial_blockaverage_subj, all_trial_blockaverage_weighted_subj, all_trial_mse_subj
+       
+    #%%
+    # # Loop over subjects
+    # blockaverage_subj = None
+    # for subj_idx, subj in enumerate(blockavg_files):
+    #     # Load in json data qual
+    #     with open(data_quality_files[subj_idx], 'r') as fp:
+    #         data_quality_sub = json.load(fp)
+    #     idx_amp = np.array(data_quality_sub['idx_amp'])
+    #     idx_sat = np.array(data_quality_sub['idx_sat'])
+    #     bad_chans_sat = np.array(data_quality_sub['bad_chans_sat'])
+    #     bad_chans_amp = np.array(data_quality_sub['bad_chans_amp'])
+        
+    #     # Load in current sub's blockaverage file
+    #     with open(subj, 'rb') as f:
+    #         rec_blockavg = pickle.load(f)
+    #     blockaverage = rec_blockavg['blockaverage']
+    #     epochs_all = rec_blockavg['epochs']
+        
+    #     # Load in net cdf files
+    #     #blockaverage2 = xr.load_dataarray(blockavg_files_nc)
+    #     #epochs2 = xr.load_dataarray(epoch_files_nc)
+        
+    #     blockaverage_weighted = blockaverage.copy()
+        
+    #     n_epochs = len(epochs_all.epoch)
+    #     n_chs = len(epochs_all.channel)
+
+    #     mse_t_lst = []
+        
+    # Loop thru trial tpes
+    
+    #     # Loop thru trial tpes
+      
+    #     for idxt, trial_type in enumerate(cfg_hrf['stim_lst']): 
+            
+    #         epochs_zeromean = epochs_all.where(epochs_all.trial_type == trial_type, drop=True) - blockaverage_weighted.sel(trial_type=trial_type) # zero mean data
+    
+    #         if 'chromo' in blockaverage.dims:0].geo3d  # !!! save 2d and 3d pts in blockaverage????
+    #            }
+    
+    # # Save data a pickle for now  # !!! Change to snirf in future when its debugged
+    # with open(out, "wb") as f:        # if output is a single string, it wraps it in an output object and need to index in
+    #     pickle.dump(groupavg_results, f, protocol=pickle.HIGHEST_PROTOCOL)
+        
+    # print("Group average data saved successfully")
+    #             foo_t = epochs_zeromean.stack(measurement=['channel','chromo']).sortby('chromo')
+    #         else:
+    #             foo_t = epochs_zeromean.stack(measurement=['channel','wavelength']).sortby('wavelength')
+    #         #pdb.set_trace()
+    #         foo_t = foo_t.transpose('measurement', 'reltime', 'epoch')  # !!! this does not have trial type?
+    #         mse_t = (foo_t**2).sum('epoch') / (n_epochs - 1)**2 # this is squared to get variance of the mean, aka MSE of the mean
+            
+    #         # ^ this gets the variance  across epochs
+            
+
+    #         # # get the variance, correctig channels we don't trust    
+    #         # mse_t = quality.measurement_variance( # this gets the measurement variance across time ... only good for timeseries
+    #         #         foo_t,
+    #         #         list_bad_channels = None, #idx_bad_channels,  # !!! where to get this?  -- before this was where mse_t = 0
+    #         #         bad_rel_var = 1e6, # If bad_abs_var is none then it uses this value relative to maximum variance
+    #         #         bad_abs_var = None, #cfg_blockavg['cfg_mse_conc']['mse_val_for_bad_data'],
+    #         #         calc_covariance = False
+    #         #     )
+            
+    #         # mse_t = blockaverage_weighted + cfg_mse['mse_min_thresh'] # set a small value to avoid dominance for low variance channels
+    #         # blockaverage_weighted.loc[dict(channel=blockaverage_weighted.isel(channel=idx_amp).channel.data)] = cfg_mse['blockaverage_val']
+    #         # blockaverage_weighted.loc[dict(channel=blockaverage_weighted.isel(channel=idx_sat).channel.data)] = cfg_mse['blockaverage_val']
+    
+    #         # !!! maybe have the above func have a helper func that is called variance_clean  
+    
+    #         # Set bad values in mse_t to the bad value threshold
+    #         bad_mask = mse_t.data == 0
+    #         bad_any = bad_mask.any(axis=1)
+    #         bad_chans_mse = mse_t.channel[bad_any].values
+    #         # bad_chans_mse = set(mse_t.channel[bad_any].values)
+
+    #         # idx_bad = np.where(mse_t == 0)[0]
+    #         # idx_bad1 = idx_bad[idx_bad<n_chs]
+    #         # idx_bad2 = idx_bad[idx_bad>=n_chs] - n_chs
+            
+    #         # mse_t[idx_amp,:] = cfg_mse['mse_val_for_bad_data']
+    #         # mse_t[idx_amp+n_chs,:] = cfg_mse['mse_val_for_bad_data']
+    #         # mse_t[idx_sat,:] = cfg_mse['mse_val_for_bad_data']    
+
+    #         # mse_t[idx_sat+n_chs,:] = cfg_mse['mse_val_for_bad_data']
+         
+    #         # mse_t.loc[dict(channel=bad_chans_amp)] = cfg_mse['mse_val_for_bad_data']
+    #         # mse_t.loc[dict(channel=bad_chans_sat)] = cfg_mse['mse_val_for_bad_data']
+    #         mse_t[mse_t.channel.isin(bad_chans_amp), :] = cfg_mse['mse_val_for_bad_data']
+    #         mse_t[mse_t.channel.isin(bad_chans_sat), :] = cfg_mse['mse_val_for_bad_data']
+    #         mse_t[mse_t.channel.isin(bad_chans_mse), :] = cfg_mse['mse_val_for_bad_data']
+    #         # mse_t[idx_bad] = cfg_mse['mse_val_for_bad_data']
+    #         # mse_t.loc[dict(channel=bad_chans_mse)] = cfg_mse['mse_val_for_bad_data']
+            
+    #         channels = blockaverage_weighted.channel
+    #         blockaverage_weighted.loc[dict(trial_type=trial_type, channel=bad_chans_sat)] = cfg_mse['blockaverage_val']
+    #         blockaverage_weighted.loc[dict(trial_type=trial_type, channel=bad_chans_amp)] = cfg_mse['blockaverage_val']
+    #         blockaverage_weighted.loc[dict(trial_type=trial_type, channel=bad_chans_mse)] = cfg_mse['blockaverage_val']
+    #         #blockaverage_weighted.loc[dict(trial_type=trial_type, channel=bad_chans_mse)] = cfg_mse['blockaverage_val']
+            
+    #         blockaverage.loc[dict(trial_type=trial_type, channel=bad_chans_amp)] = cfg_mse['blockaverage_val']
+    #         blockaverage.loc[dict(trial_type=trial_type, channel=bad_chans_sat)] = cfg_mse['blockaverage_val']
+    #         blockaverage.loc[dict(trial_type=trial_type, channel=bad_chans_mse)] = cfg_mse['blockaverage_val']
+    #         #blockaverage.loc[dict(trial_type=trial_type, channel=bad_chans_mse)] = cfg_mse['blockaverage_val']
+    
+    
+    #         # !!! DO we still wanna do this?
+    #         # set the minimum value of mse_t
+    #         #mse_t = xr.where(mse_t < cfg_mse['mse_min_thresh'], cfg_mse['mse_min_thresh'], mse_t)
+            
+    #         if 'chromo' in blockaverage.dims:
+    #             mse_t = mse_t.unstack('measurement').transpose('chromo','channel','reltime')  
+    #         else:
+    #             mse_t = mse_t.unstack('measurement').transpose('wavelength','channel','reltime')  # !!! xrutils.other_dim
+                
+    #         mse_t = mse_t.expand_dims('trial_type')
+    #         source_coord = blockaverage_weighted['source']
+    #         mse_t = mse_t.assign_coords(source=('channel',source_coord.data))
+    #         detector_coord = blockaverage_weighted['detector']
+    #         mse_t = mse_t.assign_coords(detector=('channel',detector_coord.data))
+            
+            
+    #         mse_t = mse_t.assign_coords(trial_type = [trial_type]) # assign coords to match curr trial type
+    #         mse_t_lst.append(mse_t) # append mse_t for curr trial type to list
+
+    #         # DONE LOOP OVER TRIAL TYPES
+            
+    #     mse_t_tmp = xr.concat(mse_t_lst, dim='trial_type') # concat the 2 trial types
+    #     mse_t = mse_t_tmp # reassign the newly appended mse_t with both trial types to mse_t 
+
+        
+    #     # gather the blockaverage across subjects
+    #     if blockaverage_subj is None: 
+    #         # add a subject dimension and coordinate
+    #         blockaverage_subj = blockaverage.expand_dims('subj')
+    #         blockaverage_subj = blockaverage_subj.assign_coords(subj=[cfg_dataset['subject'][subj_idx]]) # !!! will need to update when exluding subs
+
+    #         blockaverage_mse_subj = mse_t.expand_dims('subj') # mse of blockaverage for each sub
+    #         blockaverage_mse_subj = blockaverage_mse_subj.assign_coords(subj=[cfg_dataset['subject'][subj_idx]]) # !!! does snakemake give list of files in order of sub list?
+            
+    #         blockaverage_mean_weighted = blockaverage_weighted / mse_t
+
+    #         blockaverage_mse_inv_mean_weighted = 1 / mse_t
+            
+    #     else:   
+    #         #blockaverage_subj_tmp = blockaverage_weighted
+    #         blockaverage_subj_tmp = blockaverage.expand_dims('subj')
+    #         blockaverage_subj_tmp = blockaverage_subj_tmp.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
+    #         blockaverage_subj = xr.concat([blockaverage_subj, blockaverage_subj_tmp], dim='subj')
+
+    #         blockaverage_mse_subj_tmp = mse_t.expand_dims('subj')
+            
+    #         blockaverage_mse_subj_tmp = blockaverage_mse_subj_tmp.assign_coords(subj=[cfg_dataset['subject'][subj_idx]])
+    #         blockaverage_mse_subj = xr.concat([blockaverage_mse_subj, blockaverage_mse_subj_tmp], dim='subj') # !!! this does not have trial types
+
+    #         blockaverage_mean_weighted = blockaverage_mean_weighted +  blockaverage_weighted / mse_t
+    #         blockaverage_mse_inv_mean_weighted = blockaverage_mse_inv_mean_weighted + 1/mse_t 
+        
+    #     # DONE LOOP OVER SUBJECTS
+        
+    # # get the unweighted average
+    # blockaverage_mean = blockaverage_subj.mean('subj')
+    
+    # # get the weighted average  (old)
+    # #blockaverage_mean_weighted = blockaverage_mean_weighted / blockaverage_mse_inv_mean_weighted
+    
+    # # get the mean mse within subjects
+    # mse_mean_within_subject = 1 / blockaverage_mse_inv_mean_weighted
+
+    # # get the mse between subjects
+    # mse_weighted_between_subjects_tmp = (blockaverage_subj - blockaverage_mean_weighted)**2 / blockaverage_mse_subj   # was -blockaverage_mean_weighted
+    # mse_weighted_between_subjects = mse_weighted_between_subjects_tmp.mean('subj')
+    # mse_weighted_between_subjects = mse_weighted_between_subjects * mse_mean_within_subject  # normalized by the within subject variances as weights
+ 
+    # # get the weighted average
+    # mse_btw_within_sum_subj = blockaverage_mse_subj + mse_weighted_between_subjects
+    # denom = (1/mse_btw_within_sum_subj).sum('subj')
+    
+    # blockaverage_mean_weighted = (blockaverage_subj / mse_btw_within_sum_subj).sum('subj') # !!! reassinging blockaverage_mean_weighted
+    # blockaverage_mean_weighted = blockaverage_mean_weighted / denom
+    
+    # mse_total = 1/denom
+    
+    # total_stderr_blockaverage = np.sqrt( mse_total )
+    # total_stderr_blockaverage = total_stderr_blockaverage.assign_coords(trial_type=blockaverage_mean_weighted.trial_type)
+    
+    
+    
+    # # # !!! Do we want these plots still? Would need to also load in a rec ???  - or just load in saved geo2d and geo3d?
+    # # # # Plot scalp plot of mean, tstat,rsme + Plot mse hist
+    # # # for idxt, trial_type in enumerate(blockaverage_mean_weighted.trial_type.values):         
+    # # #     plot_mean_stderr(rec, rec_str, trial_type, cfg_dataset, cfg_blockavg, blockaverage_mean_weighted, 
+    # # #                      total_stderr_blockaverage, mse_mean_within_subject, mse_weighted_between_subjects)
+    # # #     plot_mse_hist(rec, rec_str, trial_type, cfg_dataset, blockaverage_mse_subj, cfg_blockavg['mse_val_for_bad_data'], cfg_blockavg['mse_min_thresh'])  # !!! not sure if these r working correctly tbh
+    
+    
+    # groupavg_results = {'group_blockaverage_weighted': blockaverage_mean_weighted, # weighted group avg   
+    #             'group_blockaverage': blockaverage_mean,  # unweighted group aaverage
+    #            'total_stderr_blockaverage': total_stderr_blockaverage,
+    #            'blockaverage_subj': blockaverage_subj,  # always unweighted   - load into img recon
+    #            'blockaverage_mse_subj': blockaverage_mse_subj, # - load into img recon
+    #            # 'geo2d' : geo2d,
+    #            # 'geo3d' : geo3d     # !!! save 2d and 3d pts in blockaverage????
+    #            }
+    
+    # # Save data a pickle for now  # !!! Change to snirf in future when its debugged
+    # with open(out, "wb") as f:        # if output is a single string, it wraps it in an output object and need to index in
+    #     pickle.dump(groupavg_results, f, protocol=pickle.HIGHEST_PROTOCOL)
+        
+    # print("Group average data saved successfully")
+
+
+def plot_mean_stderr(rec, rec_str, trial_type, cfg_dataset, cfg_blockavg, blockaverage_mean_weighted, blockaverage_stderr_weighted, mse_mean_within_subject, mse_weighted_between_subjects, geo3d):
+    # scalp_plot the mean, stderr and t-stat
+    #######################################################
+    
+    # blockaverage_mean_weighted_t = blockaverage_mean_weighted.sel(trial_type=trial_type)
+    # blockaverage_stderr_weighted_t = blockaverage_stderr_weighted.sel(trial_type=trial_type)
+    # mse_mean_within_subject_t = mse_mean_within_subject.sel(trial_type=trial_type)
+    # mse_weighted_between_subjects_t = mse_weighted_between_subjects.sel(trial_type=trial_type)
+    
+    blockaverage_mean_weighted_t = blockaverage_mean_weighted
+    blockaverage_stderr_weighted_t = blockaverage_stderr_weighted
+    mse_mean_within_subject_t = mse_mean_within_subject
+    mse_weighted_between_subjects_t = mse_weighted_between_subjects
+    
+    if 'chromo' in blockaverage_mean_weighted_t.dims:
+        n_wav_chromo = blockaverage_mean_weighted_t.chromo.size
+        name_conc_od = 'conc'
+    else:
+        n_wav_chromo = blockaverage_mean_weighted_t.wavelength.size
+        name_conc_od = 'od'
+
+    for i_wav_chromo in range(n_wav_chromo):
+        f,ax = p.subplots(2,2,figsize=(10,10))
+
+        ax1 = ax[0,0]
+        if 'reltime' in blockaverage_mean_weighted_t.dims:
+            foo_da = blockaverage_mean_weighted_t.sel(reltime=slice(cfg_blockavg['trange_hrf_stat'][0], cfg_blockavg['trange_hrf_stat'][1])).mean('reltime')
+        else:
+            foo_da = blockaverage_mean_weighted_t
+        #foo_da = foo_da[0,:,:]
+        title_str = 'Mean_' + name_conc_od + '_' + trial_type
+        if 'chromo' in foo_da.dims:
+            foo_da_tmp = foo_da.isel(chromo=i_wav_chromo)
+        else:
+            foo_da_tmp = foo_da.isel(wavelength=i_wav_chromo)
+        max_val = np.nanmax(np.abs(foo_da_tmp.values))
+        plots.scalp_plot(
+                rec[rec_str],
+                geo3d,
+                foo_da_tmp,
+                ax1,
+                cmap='jet',
+                vmin=-max_val,
+                vmax=max_val,
+                optode_labels=False,
+                title=title_str,
+                optode_size=6
+            )
+
+        ax1 = ax[0,1]
+        if 'reltime' in blockaverage_mean_weighted_t.dims:
+            foo_numer = blockaverage_mean_weighted_t.sel(reltime=slice(cfg_blockavg['trange_hrf_stat'][0], cfg_blockavg['trange_hrf_stat'][1])).mean('reltime')
+            foo_denom = blockaverage_stderr_weighted_t.sel(reltime=slice(cfg_blockavg['trange_hrf_stat'][0], cfg_blockavg['trange_hrf_stat'][1])).mean('reltime')
+            foo_da = foo_numer / foo_denom
+        else:
+            foo_da = blockaverage_mean_weighted_t / blockaverage_stderr_weighted_t
+        #foo_da = foo_da[0,:,:]
+        title_str = 'T-Stat_'+ name_conc_od + '_' + trial_type
+        if 'chromo' in foo_da.dims:
+            foo_da_tmp = foo_da.isel(chromo=i_wav_chromo)
+        else:
+            foo_da_tmp = foo_da.isel(wavelength=i_wav_chromo)
+        max_val = np.nanmax(np.abs(foo_da_tmp.values))
+        plots.scalp_plot(
+                rec[rec_str],
+                geo3d,
+                foo_da_tmp,
+                ax1,
+                cmap='jet',
+                vmin=-max_val,
+                vmax=max_val,
+                optode_labels=False,
+                title=title_str,
+                optode_size=6
+            )
+        
+        ax1 = ax[1,0]
+        if 'reltime' in blockaverage_mean_weighted_t.dims:
+            foo_da = mse_mean_within_subject_t.sel(reltime=slice(cfg_blockavg['trange_hrf_stat'][0], cfg_blockavg['trange_hrf_stat'][1])).mean('reltime')
+        else:
+            foo_da = mse_mean_within_subject_t
+        #foo_da = foo_da[0,:,:]
+        foo_da = foo_da**0.5
+        title_str = 'log10(RMSE) within subjects ' + name_conc_od + ' ' + trial_type
+        if 'chromo' in foo_da.dims:
+            foo_da_tmp = foo_da.isel(chromo=i_wav_chromo)
+            foo_da_tmp = foo_da_tmp.pint.dequantify()
+        else:
+            foo_da_tmp = foo_da.isel(wavelength=i_wav_chromo)
+        foo_da_tmp = np.log10(foo_da_tmp)
+        max_val = np.nanmax(foo_da_tmp.values)
+        min_val = np.nanmin(foo_da_tmp.values)
+        plots.scalp_plot(
+                rec[rec_str],
+                geo3d,
+                foo_da_tmp,
+                ax1,
+                cmap='jet',
+                vmin=min_val,
+                vmax=max_val,
+                optode_labels=False,
+                title=title_str,
+                optode_size=6
+            )
+
+        ax1 = ax[1,1]
+        if 'reltime' in blockaverage_mean_weighted_t.dims:
+            foo_da = mse_weighted_between_subjects_t.sel(reltime=slice(cfg_blockavg['trange_hrf_stat'][0], cfg_blockavg['trange_hrf_stat'][1])).mean('reltime')
+        else:
+            foo_da = mse_weighted_between_subjects_t
+        #foo_da = foo_da[0,:,:]
+        foo_da = foo_da**0.5
+        title_str = 'log10(RMSE) between subjects ' + name_conc_od + ' ' + trial_type 
+        if 'chromo' in foo_da.dims:
+            foo_da_tmp = foo_da.isel(chromo=i_wav_chromo)
+            foo_da_tmp = foo_da_tmp.pint.dequantify()
+        else:
+            foo_da_tmp = foo_da.isel(wavelength=i_wav_chromo)
+        foo_da_tmp = np.log10(foo_da_tmp)
+        max_val = np.nanmax(foo_da_tmp.values)
+        min_val = np.nanmin(foo_da_tmp.values)
+        plots.scalp_plot(
+                rec[rec_str],
+                geo3d,
+                foo_da_tmp,
+                ax1,
+                cmap='jet',
+                vmin=min_val,
+                vmax=max_val,
+                optode_labels=False,
+                title=title_str,
+                optode_size=6
+            )
+                
+        # give a title to the figure and save it
+        dirnm = os.path.basename(os.path.normpath(cfg_dataset['root_dir']))
+        if 'chromo' in foo_da.dims:
+            title_str = f"{dirnm} - {name_conc_od} {trial_type} {foo_da.chromo.values[i_wav_chromo]} ({cfg_blockavg['trange_hrf_stat'][0]} to {cfg_blockavg['trange_hrf_stat'][1]} s)"
+        else:
+            title_str = f"{dirnm} - {name_conc_od} {trial_type} {foo_da.wavelength.values[i_wav_chromo]:.0f}nm ({cfg_blockavg['trange_hrf_stat'][0]} to {cfg_blockavg['trange_hrf_stat'][1]} s)"
+        p.suptitle(title_str)
+
+        save_dir = os.path.join(cfg_dataset['root_dir'], 'derivatives', cfg_dataset['derivatives_subfolder'], 'plots', 'DQR', 'group_weighted_avg')
+        os.makedirs(save_dir, exist_ok=True)
+        
+        if 'chromo' in foo_da.dims:
+            p.savefig( os.path.join(save_dir, f'DQR_group_weighted_avg_{name_conc_od}_{trial_type}_{foo_da.chromo.values[i_wav_chromo]}.png') )
+        else:
+            p.savefig( os.path.join(save_dir, f'DQR_group_weighted_avg_{name_conc_od}_{trial_type}_{foo_da.wavelength.values[i_wav_chromo]:.0f}nm.png') )
+        p.close()
+
+
+def plot_mse_hist(rec, rec_str, trial_type, cfg_dataset, blockaverage_mse_subj, mse_val_for_bad_data, mse_min_thresh):
+    # plot the MSE histogram
+    ########################################################
+    #pdb.set_trace()
+    blockaverage_mse_subj_t = blockaverage_mse_subj #.sel(trial_type = trial_type)
+    
+    f,ax = p.subplots(2,1,figsize=(6,10))
+
+    # plot the diagonals for all subjects
+    ax1 = ax[0]
+    if 'reltime' in blockaverage_mse_subj_t.dims:
+        foo = blockaverage_mse_subj_t.mean('reltime')
+    else:
+        foo = blockaverage_mse_subj_t
+    
+    if 'chromo' in blockaverage_mse_subj.dims:
+        foo = foo.stack(measurement=['channel','chromo']).sortby('chromo')
+        name_conc_od = 'conc'
+    else:
+        foo = foo.stack(measurement=['channel','wavelength']).sortby('wavelength')
+        name_conc_od = 'od'
+
+    n_subjects = foo.shape[0]  
+
+    for i in range(n_subjects):
+        ax1.semilogy(foo[i,:], linewidth=0.5,alpha=0.5)
+    ax1.set_title('variance in the mean for all subjects')
+    ax1.set_xlabel('channel')
+    ax1.legend()
+
+    # histogram the diagonals
+    ax1 = ax[1]
+    foo1 = np.concatenate([foo[i] for i in range(n_subjects)]) # FIXME: need to loop over files too   # was foo[i][0] not sure what [0] was for, maybe trial type?
+    # check if mse_val_for_bad_data has units
+    if 'chromo' in blockaverage_mse_subj.dims:
+        foo1 = np.where(foo1 == 0, mse_val_for_bad_data.magnitude, foo1) # some bad data gets through. amp=1e-6, but it is missed by the check above. Only 2 channels in 9 subjects. Seems to be channel 271
+    else:
+        foo1 = np.where(foo1 == 0, mse_val_for_bad_data, foo1)
+    ax1.hist(np.log10(foo1), bins=100)
+    
+    if 'chromo' in blockaverage_mse_subj.dims:
+        ax1.axvline(np.log10(mse_min_thresh.magnitude), color='r', linestyle='--', label=f'cov_min_thresh={mse_min_thresh.magnitude:.2e}')
+    else:
+        ax1.axvline(np.log10(mse_min_thresh), color='r', linestyle='--', label=f'cov_min_thresh={mse_min_thresh:.2e}')
+        
+    ax1.legend()
+    ax1.set_title(f'{name_conc_od} {trial_type} - histogram for all subjects of variance in the mean')
+    ax1.set_xlabel('log10(cov_diag)')
+
+    # give a title to the figure and save it
+    dirnm = os.path.basename(os.path.normpath(cfg_dataset['root_dir']))
+    p.suptitle(f'Data set - {dirnm}')
+
+    save_dir = os.path.join(cfg_dataset['root_dir'], 'derivatives', cfg_dataset['derivatives_subfolder'], 'plots', 'DQR', 'group_weighted_avg')
+    os.makedirs(save_dir, exist_ok=True)
+
+    p.savefig( os.path.join(save_dir, f'DQR_group_mse_histogram_{name_conc_od}_{trial_type}.png') )
+    p.close()
+
+    
+    
+#%%
 # import matplotlib.pyplot as plt
 # mse_avg_per_channel = mse_t.mean(dim='reltime')
 
@@ -489,12 +751,13 @@ def main():
     
     blockavg_files = snakemake.input.blockavg_subs  #.preproc_runs
     data_quality_files = snakemake.input.quality
+    geo_files = snakemake.input.geo
     #blockavg_files_nc = snakemake.input.blockavg_nc
     #epoch_files_nc = snakemake.input.epochs_nc
     
     out = snakemake.output[0]
 
-    groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, flag_prune_channels, blockavg_files, data_quality_files, out)
+    groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, flag_prune_channels, blockavg_files, data_quality_files, geo_files, out)
     
             
 if __name__ == "__main__":

--- a/workflow/scripts/modules/module_plot_DQR.py
+++ b/workflow/scripts/modules/module_plot_DQR.py
@@ -69,7 +69,7 @@ def plotDQR( rec, chs_pruned, cfg_preprocess, filenm, cfg_dataset, cfg_hrf): #, 
     norm = clrs.BoundaryNorm(bounds, cmap.N)
         
     cb_ticks_labels = [(0.08,'SDS'), (0.24,'Low Signal'), (0.4,'Poor SNR'), (0.58,'Good SNR'), (0.76,'SCI/PSP'), (0.92,'Saturated')]
-
+    #pdb.set_trace()
     idx_good = np.where(chs_pruned.values == 0.58)[0]
     plots.scalp_plot( 
             rec["amp"],

--- a/workflow/scripts/modules/module_preprocess.py
+++ b/workflow/scripts/modules/module_preprocess.py
@@ -159,7 +159,7 @@ def pruneChannels( rec, cfg_prune ):
     elif cfg_prune['flag_use_psp']:
         sci_x_psp_mask = psp_mask
     else:
-        return rec, chs_pruned, sci, psp
+        return rec, chs_pruned #, sci, psp
 
     perc_time_clean = sci_x_psp_mask.sum(dim="time") / len(sci.time)
     perc_time_mask = xrutils.mask(perc_time_clean, True)
@@ -176,10 +176,10 @@ def pruneChannels( rec, cfg_prune ):
 
     # modify xarray of channel labels with value of 0.95 for channels that are pruned by SCI and/or PSP
     chs_pruned.loc[drop_list] = 0.76     # was 0.95
-
-    rec.set_mask('chs_pruned', chs_pruned)
+    # pdb.set_trace()
+    # rec.set_mask('chs_pruned', chs_pruned)
     
-    return rec
+    return rec, chs_pruned
 
 
 def GLM(rec, rec_str, cfg_GLM, cfg_hrf, pruned_chans):

--- a/workflow/scripts/testing/config_test.yaml
+++ b/workflow/scripts/testing/config_test.yaml
@@ -1,26 +1,29 @@
 dataset:
   root_dir: '/projectnb/nphfnirs/ns/Shannon/Data/Interactive_Walking_HD'   #test_250616'   #Interactive_Walking_HD"
-  #root_dir: "/projectnb/nphfnirs/s/datasets/BSMW_Laura_Miray_2025/BS"
-  #root_dir: "D:/fNIRS/DATA/Interactive_Walking_HD"
-  derivatives_subfolder: "cedalion/test"
-  #subject: ["547", "568", "577", "580", "581", "583","586", "587", "588", "592", "613"]  #, "618","619", "621", "633", "638", "639", "640"]
-  subject: ["01", "02", "03", "04", "05", "06"] #, "07", "08", "09", "10", "11", "12", "13", "15", "19", "20", "21", "22", "23", "24", "25", "26", "28"]  # ['nc261'] #
-  task: ["STS"]  #["STS"]                    # , "BS"
-  run: ["01"]  #, "02", "03"]         # !!! SHOULD we just have snakemake parse thru the number of runs? what if a sub only has 2 runs but all others have 3
+  # root_dir: "D:/fNIRS/DATA/Interactive_Walking_HD"
+  derivatives_subfolder: "cedalion/test_9subs" 
+  subject: ["01", "02", "03", "04", "05", "06", "07", "08", "09"]  #, "10", "11", "12", "13", "15", "19", "20", "21", "22", "23", "24", "25", "26", "28"]  # ['nc261'] #
+  task: ['STS']
+  run: ["01"]    # !!! SHOULD we just have snakemake parse thru the number of runs? what if a sub only has 2 runs but all others have 3
     
 hrf:  # !!! make these constants instead?
-  stim_lst: ['STS']  # ['ST', 'DT'] # ["right", "left"]  #["STS"]  # make this in script instead of adding?  # auto but then add exlusion
-  t_pre: "5 second"  #"2 second"  # can we make this a lsit for diff trial types for GLM
-  t_post: "33 second" #"16 second" 
+  stim_lst: ['STS']  # make this in script instead of adding?  # auto but then add exlusion
+  t_pre: "5 second"   # can we make this a lsit for diff trial types for GLM
+  t_post: "33 second" 
 
 preprocess:
   steps:
+    bs_preproc:   # !!! only for BS data
+      enable: false
+      probe_dir: "/projectnb/nphfnirs/s/users/lcarlton/DATA/probes/NN22_WHHD/12NN/" #probe_dir: "/projectnb/nphfnirs/ns/Shannon/Data/probes/NN22_WHHD/12NN/"
+      snirf_name_probe: "fullhead_56x144_System2.snirf"  #"fullhead_56x144_NN22_System1.snirf"
+  
     median_filter:
       enable: true
       order: 1
 
     prune:
-      enable: false  # false, does not update timeseries but does return mask  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+      enable: true  # false, does not update timeseries but does return mask  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
       snr_thresh: 5
       sd_thresh:
         - "1 mm"
@@ -71,7 +74,7 @@ preprocess:
       enable: true
 
     GLM_filter:
-      enable: true
+      enable: false
       drift_order: 1
       distance_threshold: "20 mm"   # for ssr
       short_channel_method: "mean"
@@ -96,8 +99,8 @@ groupaverage:
    mse_min_thresh: "1e0 micromolar**2"
    blockaverage_val: "0 micromolar**2"
   mse_od:
-   mse_val_for_bad_data: 1e1
-   mse_min_thresh: 1e-3 #1e-6
+   mse_val_for_bad_data: 10
+   mse_min_thresh: 1e-6  #1e-6
    blockaverage_val: 0
    
    
@@ -109,18 +112,18 @@ image_recon:
   BRAIN_ONLY:      # reconstruct brain only OR scalp and brain
     enable: false
   spatial_basis:           
-    enable: false 
+    enable: true 
     mask_threshold: -2
     threshold_brain: "1 mm"
     threshold_scalp: "5 mm"
     sigma_brain: "1 mm"
     sigma_scalp: "5 mm"
-  t_win: [4, 7]
+  t_win: [10, 20] 
   probe_dir: "/projectnb/nphfnirs/ns/Shannon/Data/probes/NN22_WHHD/12NN/"
   snirf_name_probe: "fullhead_56x144_NN22_System1.snirf"
   head_model: 'ICBM152'
-  alpha_meas: 1e-2
-  alpha_spatial: 1e-3
+  alpha_meas: 1e4
+  alpha_spatial: 1e-2
   spectrum: 'prahl'
   mse_min_thresh: 1e-6   # where is this used
   plot_image:

--- a/workflow/scripts/testing/test_blockaverage.py
+++ b/workflow/scripts/testing/test_blockaverage.py
@@ -45,13 +45,14 @@ for subj in subjects:
         
         run_files = [os.path.join(preproc_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_run-{r}_nirs_preprocessed.snirf") for r in run]
         
-        data_quality_files = [os.path.join(preproc_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_run-{r}_nirs_dataquality.json") for r in run]
+        data_quality_files = [os.path.join(preproc_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_run-{r}_nirs_dataquality_geo.sidecar") for r in run]
         
         # run_files = ["/projectnb/nphfnirs/ns/Shannon/Data/Interactive_Walking_HD/derivatives/cedalion/preprocessed_data/sub-01/sub-01_task-STS_run-01_nirs_preprocessed.snirf"]
         
         save_path = os.path.join(cfg_dataset['root_dir'], "derivatives", cfg_dataset['derivatives_subfolder'], "blockaverage", f"sub-{subj}")
         out_pkl = os.path.join(save_path,f"sub-{subj}_task-{task}_nirs_blockaverage.pkl")
         out_json = os.path.join(save_path,f"sub-{subj}_task-{task}_nirs_dataquality.json")
+        out_geo = os.path.join(save_path,f"sub-{subj}_task-{task}_nirs_geo.sidecar")
         #out_blkavg_nc = os.path.join(save_path, f"sub-{subj}_task-{task}_nirs_blockaverage.nc")
         #out_epoch_nc = os.path.join(save_path, f"sub-{subj}_task-{task}_nirs_epochs.nc")
         
@@ -59,5 +60,5 @@ for subj in subjects:
                 
         print(f"Processing sub-{subj}, task-{task} ...")
         
-        blockavg.blockaverage_func(cfg_dataset, cfg_blockaverage_loop, cfg_hrf_loop, run_files, data_quality_files, out_pkl, out_json)
+        blockavg.blockaverage_func(cfg_dataset, cfg_blockaverage_loop, cfg_hrf_loop, run_files, data_quality_files, out_pkl, out_json, out_geo)
         

--- a/workflow/scripts/testing/test_groupaverage.py
+++ b/workflow/scripts/testing/test_groupaverage.py
@@ -17,7 +17,7 @@ importlib.reload(groupavg)
 
 # config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/config/config.yaml"
 #config_path = "C:\\Users\\shank\\Documents\\GitHub\\cedalion-pipeline\\workflow\\config\\config.yaml"
-config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/scripts/testing/config_test.yaml" # CHANGE if testing
+config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/scripts/testing/config_test_BS.yaml" # CHANGE if testing
 
 
 with open(config_path, 'r') as file:
@@ -37,8 +37,9 @@ task = cfg_dataset['task'][0]
 blockavg_dir = os.path.join(cfg_dataset['root_dir'], "derivatives", cfg_dataset['derivatives_subfolder'], "blockaverage")  #, f"sub-{subj}")
 blockavg_files = [os.path.join(blockavg_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_nirs_blockaverage.pkl") for subj in subjects ]
 data_quality_files = [os.path.join(blockavg_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_nirs_dataquality.json") for subj in subjects ]
-blockavg_files_nc = [os.path.join(blockavg_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_nirs_blockaverage.nc") for subj in subjects ]
-epoch_files_nc = [os.path.join(blockavg_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_nirs_epochs.nc") for subj in subjects ]
+geo_files = [os.path.join(blockavg_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_nirs_geo.sidecar") for subj in subjects ]
+# blockavg_files_nc = [os.path.join(blockavg_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_nirs_blockaverage.nc") for subj in subjects ]
+# epoch_files_nc = [os.path.join(blockavg_dir, f"sub-{subj}", f"sub-{subj}_task-{task}_nirs_epochs.nc") for subj in subjects ]
 
 
 save_path = os.path.join(cfg_dataset['root_dir'], "derivatives", cfg_dataset['derivatives_subfolder'], "groupaverage")
@@ -48,5 +49,5 @@ der_dir = os.path.join(save_path)
 if not os.path.exists(der_dir):
     os.makedirs(der_dir)
         
-groupavg.groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, flag_prune_channels, blockavg_files, data_quality_files, out)
+groupavg.groupaverage_func(cfg_dataset, cfg_blockaverage, cfg_hrf, cfg_groupaverage, flag_prune_channels, blockavg_files, data_quality_files, geo_files, out)
 

--- a/workflow/scripts/testing/test_img_recon.py
+++ b/workflow/scripts/testing/test_img_recon.py
@@ -20,7 +20,7 @@ import importlib
 importlib.reload(img_recon)
 # 
 # config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/config/config.yaml"
-config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/scripts/testing/config_test.yaml"
+config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/scripts/testing/config_test_BS.yaml"
 
 
 with open(config_path, 'r') as file:

--- a/workflow/scripts/testing/test_preproc.py
+++ b/workflow/scripts/testing/test_preproc.py
@@ -20,7 +20,7 @@ importlib.reload(preproc)
 
 #config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/config/config.yaml" # CHANGE if testing
 #config_path = "C:\\Users\\shank\\Documents\\GitHub\\cedalion-pipeline\\workflow\\config\\config.yaml"
-config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/scripts/testing/config_test.yaml" # CHANGE if testing
+config_path = "/projectnb/nphfnirs/ns/Shannon/Code/cedalion-pipeline/workflow/scripts/testing/config_test_BS.yaml" # CHANGE if testing
 
 
 with open(config_path, 'r') as file:  # open config file
@@ -47,23 +47,20 @@ for subj in subjects:
             events_path =  f"{cfg_dataset['root_dir']}/sub-{subj}/nirs/sub-{subj}_task-{task}_run-{run}_events.tsv"
             
             save_path = f"{cfg_dataset['root_dir']}/derivatives/{cfg_dataset['derivatives_subfolder']}/preprocessed_data/sub-{subj}/"
-            out_snirf = f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_preprocessed.snirf"
-            out_json = f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_dataquality.json"
+            
+            #out_snirf = f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_preprocessed.snirf"
+            #out_json = f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_dataquality.json"
             
             out_files = {
                 "out_snirf" : f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_preprocessed.snirf",
-                "out_json": f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_dataquality.json",
-                "out_dqr": f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_DQR.png",
-                "out_gvtd": f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_DQR_gvtd_hist.png",
-                "out_slope": f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_slope.png"
+                "out_sidecar": f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_dataquality_geo.sidecar",
+                #"out_dqr": f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_DQR.png",
+                #"out_gvtd": f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_DQR_gvtd_hist.png",
+                #"out_slope": f"{save_path}sub-{subj}_task-{task}_run-{run}_nirs_slope.png"
                 }
             
             os.makedirs(save_path, exist_ok=True)  # make directory if it doesn't already exist
-            
-            # der_dir = os.path.join(save_path)
-            # if not os.path.exists(der_dir):
-            #     os.makedirs(der_dir)
-            
+
             print(f"Processing sub-{subj}, task-{task}, run-{run}...")
             
             preproc.preprocess_func(config, snirf_path, events_path, cfg_dataset, cfg_preprocess_loop, cfg_hrf_loop, mse_amp_thresh_loop, out_files)


### PR DESCRIPTION
snakefile 
- changed data quality .json to .sidecar file
- Changed output of preprocess to be pkl instead of snirf 
- Saving geometric coordinates in file from blockaverage
- groupaverage now loads in geometric coords  -- could put in data qual in future
- 
scripts/blockaverage.py
- now takes ijn geometric coordinates as input to func
- load in pkl from preproc instead of snirf
- load in sidecar instead of json data qual
- now saving blockaverage data in dictionary instead of snirf

scripts/groupaverage.py
- now includes geometric coords as input to func
- using the channel coords as index to change bad channels to predetermined value instead of index loc (issue with saving and loading in data, snirf reorders the channels)
- added plotting functions to plot standard error and mse histograms -- saved in plots/DQR/__ folder
- changed to using diff version of code to calc weighted group average

scripts/imagerecon.py
- **TESTING THINGS* added lines of code to reorder blockaverage data to be the same channel order as Adot (why are they different order?)
- now using all_subj_X_hrf_mag to calc weighted avg instead of X_hrf_mag_mean

scripts/preprocess.py
- Added rule to preprocess ball squeeze data (has chans for 3 and 4 NN, only selecting channels we want)
-  returning chs_pruned in preproc mod instead of grabbing from rec.mask
- 

**scripts/modules:**
module_image_recon.py
- updated load probe to take in netcdf Adot file (new Cedalion update)
- Updated script so that parcel labels are saved in results x array for SB (bug fix)
- some other changes i have to look at --- took code from LC

module_preprocess.py
- returning rec and channels pruned only 
- now saving more variables in data qual sidecar - including gvtd, snr, chs_pruned, so can create group DQR plots
- saving data qual as sidecar instead of json
- saving preprocessed data as pkl instead of snirf 

testing scripts
- changed scripts to use new inputs and outputs 