### PR TITLE
Fix Windows HomerPy Snakemake pipeline launch

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -29,7 +29,12 @@ SAVE_DIR = join(ROOT, 'derivatives', 'cedalion', DERIV)
 dirs = os.listdir(ROOT) 
 subject_list = [d.replace("sub-", "") for d in dirs if os.path.isdir(os.path.join(ROOT, d)) and "sub-" in d and d.replace("sub-", "") not in config["dataset"]["subjects_to_exclude"]]
 config["dataset"]["subject"] = subject_list
-config["dataset"]["run"] = [f"{i:02d}" for i in range(1, int(config["dataset"]["num_runs"]) + 1)]
+# Use run_list directly from config if specified, otherwise fall back to num_runs for backward compatibility
+if "run_list" in config["dataset"]:
+    config["dataset"]["run"] = config["dataset"]["run_list"]
+else:
+    # Backward compatibility: generate from num_runs if run_list not provided
+    config["dataset"]["run"] = [f"{i:02d}" for i in range(1, int(config["dataset"]["num_runs"]) + 1)]
 
 
 def get_imagerecon_output(): # create file name for image recon output

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -9,7 +9,7 @@ SNAKEFILE_DIR = Path(workflow.snakefile).parent
 # Use --configfile to specify config, or use default
 
 # default_config = join(SNAKEFILE_DIR, "config", "config.yaml")  # default config file in workflow/config folder
-default_config = "/projectnb/nphfnirs/s/datasets/Interactive_Walking_HD/derivatives/cedalion/final_ihope/config_STS_Q.yaml"
+default_config = "C:\\Users\\sreek\\Documents\\software\\fnirs_data\\Interactive_Walking_HD\\derivatives\\snakemake_config.yaml"
 # default_config = "/projectnb/nphfnirs/s/users/shannon/Data/test_data_cedalion_smk/data/derivatives/cedalion/test_new_folder_config_struct/test_1/config_test_1.yml" # have snakemake copy this file into derivatives folder
 # default_config = "/projectnb/nphfnirs/s/datasets/Interactive_Walking_HD/derivatives/cedalion/new_inclQ_test_imgrecon_newnoise_2/config_STS_Q.yml" # have snakemake copy this file into derivatives folder
 # default_config = "/projectnb/nphfnirs/s/users/shannon/Data/test_data_cedalion_smk/data/derivatives/cedalion/test/test_1/config_test_1.yml" # have snakemake copy this file into derivatives folder

--- a/workflow/config/Snakefile.yaml
+++ b/workflow/config/Snakefile.yaml
@@ -1,21 +1,25 @@
 dataset:
-  root_dir: "/projectnb/nphfnirs/s/users/shannon/Data/test_data_cedalion_smk/data"
-  derivatives_subfolder: "test_0422_groupavg/test_1"
-  #subject: ["586", "587", "592", "618", "621"] 
-  subjects_to_exclude: []
-  task: ["BS"]                    
-  num_runs: 3    # !!! SHOULD we just have snakemake parse thru the number of runs? what if a sub only has 2 runs but all others have 3
+  root_dir: "/projectnb/nphfnirs/s/users/shannon/Data/test_data_cedalion_smk/data" # where your BIDS data lives
+  derivatives_subfolder: "test_new_ced"  # where to save results. Saves as: derivatives/cedalion/YOURSTRING
+  #subject: ["586", "587", "592", "618", "621"]  # subject IDs you want to include. DO NOT INCL EXCLUDED SUBS
+  subjects_to_exclude: ["587", "618"]  # list of subjects you want to EXCLUDE.
+  task: ["BS"]  # task list. Currently only do ONE task at a time.                  
+  num_runs: 3
+
+  # runs_to_exclude:   # FIXME: add this option to scripts
+  #   "586": ["01"]  # dict of runs to exclude for each subject.
+  #   "621": ["02"]
 
 preprocess:
   steps:
-    median_filter:
+    median_filter:  # process your data with a median filter
       enable: true
       order: 1
     prune:
-      enable: false  # false, does not update timeseries but does return mask  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+      enable: false  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
       snr_thresh: 5
       sd_thresh_min: "1 mm"
-      sd_thresh_max: "45 mm"
+      sd_thresh_max: "45 mm"  
       amp_thresh_min: 1e-3
       amp_thresh_max: 0.84
       perc_time_clean_thresh: 0.6  # for sci x psp mask
@@ -26,55 +30,55 @@ preprocess:
       flag_use_psp: false
     int2od:
       enable: true
-    tddr:
+    # INSERT MA CORRECTION IF ANY HERE
+    tddr:  # NOTE: can do other MA techniques instead. ie. splineSG, PCA_recurse, wavelet, 
       enable: false
-    freq_filter:
+    freq_filter:  # filter your data with a bandpass, hpf, or lpf
       enable: false
-      fmin: "0.01 Hz"
-      fmax: "0.5 Hz"
+      fmin: "0.01 Hz"  # set to 0 if you want a LPF
+      fmax: "0.5 Hz"   # set to 0 if you want a HPF
     od2conc:
       enable: true
     plot_dqr:
       enable: true
 
 hrf_estimation:   #  !!! make these constants instead?
-  rec_str: "conc"   
-  stim_lst: ["right", "left"]  #  make this in script instead of adding?  # auto but then add exlusion
-  t_pre: "2 second"   # can we make this a lsit for diff trial types for GLM
-  t_post: "10 second"
+  rec_str: "conc"   # MUST BE 'conc' OR 'od_02'    - what you want to block average
+  stim_lst: ["left", "right"]  # list of stims from events.tsv you want to estimate the HRF of
+  t_pre: "2 second"   # time before stim onset you want to model  #!!! can we make this a list for diff trial types for GLM
+  t_post: "10 second" # time after stim onset you want to model
   GLM:        
    enable: true  # if true do GLM, false do block averaging
-   do_drift: "legendre" 
+   do_drift: 'legendre'  # Options: None, 'polynomial', 'legendre'
+   drift_order: 3 
    do_short_sep: true
-   drift_order: 3
    distance_threshold: "20 mm"
    short_channel_method : "mean"
-   noise_model: "ar_irls" 
+   noise_model: "ar_irls"    #  ols, rls, wls, ar_irls, gls, glsar
    basis_func: "gaussian_kernels"
    basis_func_params:
     t_delta: "1 second"
     t_std: "1 second"
 
+
 groupaverage:
-  mse:   # conc
-   mse_amp_thresh: 1e-3 #1.1e-6 # amp vals below this thresh where we do not trust the variance estimate
+  mse:    # for changing bad values IDed in prune channels mask. change vals for conc or od
    mse_val_for_bad_data: "1e7 micromolar**2"
    mse_min_thresh: "1e0 micromolar**2"
    hrf_val: "0 micromolar"
   # mse:  # od
-  #  mse_amp_thresh: 1e-3 #1.1e-6
   #  mse_val_for_bad_data: 1e1
   #  mse_min_thresh: 1e-6
-  #  hrf_val: 0
+  #  blockaverage_val: 0
    
    
-image_recon:
+image_recon:   # need to create sensitivity matrix first. Not included here yet.
   generate_sensitivity: 
     sub_folder: 'shannon'  # optional subfolder in /derivatives/cedalion/{folder}/probe/fw  # probe must be placed in folder/probe
     forward_model: "MCX"  # MCX or NIRFASTER
-    head_model: 'icbm152'  # colin27, icbm152
-  mag:
-    enable: true
+    head_model: 'icbm152'
+  mag:   
+    enable: true  # perform image recon on magnitude of HRF averaged between time window (t_win)
     t_win: [5, 8]
   recon_mode: "mua2conc"
   Cmeas: 
@@ -88,18 +92,27 @@ image_recon:
     threshold_scalp: "5 mm"
     sigma_brain: "1 mm"
     sigma_scalp: "5 mm"
-  noise_est_method: "posterior"
-  mse:  # od
+  noise_est_method: "posterior"   # posterior or measurement are options
+  mse:    # od   - for changing bad values IDed in prune channels mask
     mse_val_for_bad_data: 1e1
     mse_min_thresh: 1e-6
     hrf_val: 0
   alpha_meas: 1e4
-  alpha_spatial: 1e-3   #   (indirect: WITH SB= 1e-2, NO SB = 1e-3)
+  alpha_spatial: 1e-3
   spectrum: 'prahl'
-  lambda_spatial_depth: 1e-6   
+  lambda_spatial_depth: 1e-6   # old val for od 1.6e-09  , now 1e-6 for both od and conc 
+  plot_image:    
+    enable: false
+    flag_hbo_list: ['hbo', 'hbr']
+    flag_brain_list: ['brain', 'scalp']  # 'brain', 'scalp' - if you want to plot either
+    flag_img_list:  ['mag', 'tstat', 'noise']
 
-  # plot_image:    
-  #   enable: false
-  #   flag_hbo_list: ['hbo', 'hbr']
-  #   flag_brain_list: ['brain', 'scalp']  # 'brain', 'scalp' - if you want to plot either
-  #   flag_img_list:  ['mag', 'tstat', 'noise']
+
+
+  
+  
+  
+  
+  
+  
+  

--- a/workflow/config/Snakefile.yaml
+++ b/workflow/config/Snakefile.yaml
@@ -75,7 +75,7 @@ groupaverage:
 image_recon:   # need to create sensitivity matrix first. Not included here yet.
   generate_sensitivity: 
     sub_folder: 'shannon'  # optional subfolder in /derivatives/cedalion/{folder}/probe/fw  # probe must be placed in folder/probe
-    forward_model: "MCX"  # MCX or NIRFASTER
+    forward_model: "MCX"  # MCX or MCXCL or NIRFASTER
     head_model: 'icbm152'
   mag:   
     enable: true  # perform image recon on magnitude of HRF averaged between time window (t_win)

--- a/workflow/config/Snakefile.yaml
+++ b/workflow/config/Snakefile.yaml
@@ -3,8 +3,9 @@ dataset:
   derivatives_subfolder: "test_new_ced"  # where to save results. Saves as: derivatives/cedalion/YOURSTRING
   #subject: ["586", "587", "592", "618", "621"]  # subject IDs you want to include. DO NOT INCL EXCLUDED SUBS
   subjects_to_exclude: ["587", "618"]  # list of subjects you want to EXCLUDE.
-  task: ["BS"]  # task list. Currently only do ONE task at a time.                  
-  num_runs: 3
+  task: ["BS"]  # task list. Currently only do ONE task at a time. 
+  num_runs: 2  # number of runs for this task. If specified, overrides run_list.                 
+  # run_list: ["01","02"]  # list of runs for this task. If specified, overrides num_runs. Format should be ["01", "02", ...]
 
   # runs_to_exclude:   # FIXME: add this option to scripts
   #   "586": ["01"]  # dict of runs to exclude for each subject.

--- a/workflow/config/Snakefile.yaml
+++ b/workflow/config/Snakefile.yaml
@@ -1,20 +1,22 @@
 dataset:
-  root_dir: "/projectnb/nphfnirs/s/datasets/Interactive_Walking_HD"  # where your BIDS data lives
-  derivatives_subfolder: "cedalion/new_inclQ_first"  # where to save results. Saves as: derivatives/cedalion/
-  subject: ["01", "02", "03", "04", "05", "06", "07", "08"]  # subject IDs you want to include. DO NOT INCL EXCLUDED SUBS
-  task: ["STS"]  # task list. Currently only do ONE task at a time.                  
-  run: ["01"]  # number of runs for this task. 
+  root_dir: "/projectnb/nphfnirs/s/users/shannon/Data/test_data_cedalion_smk/data"
+  derivatives_subfolder: "test_0422_groupavg/test_1"
+  #subject: ["586", "587", "592", "618", "621"] 
+  subjects_to_exclude: []
+  task: ["BS"]                    
+  num_runs: 3    # !!! SHOULD we just have snakemake parse thru the number of runs? what if a sub only has 2 runs but all others have 3
+
 preprocess:
   steps:
-    median_filter:  # process your data with a median filter
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+    median_filter:
+      enable: true
       order: 1
     prune:
-      enable: false  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+      enable: false  # false, does not update timeseries but does return mask  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
       snr_thresh: 5
       sd_thresh_min: "1 mm"
       sd_thresh_max: "45 mm"
-      amp_thresh_min: "1e-3"
+      amp_thresh_min: 1e-3
       amp_thresh_max: 0.84
       perc_time_clean_thresh: 0.6  # for sci x psp mask
       sci_threshold: 0.6
@@ -23,60 +25,58 @@ preprocess:
       flag_use_sci: true
       flag_use_psp: false
     int2od:
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
-    calc_slope_b4:  # calc slope before correction applied to od
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
-    calc_gvtd_b4:  # calc gvtd before correction applied to od
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
-    tddr:  # NOTE: can do other MA techniques instead. ie. splineSG, PCA_recurse, wavelet, 
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
-    calc_slope_after:
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
-    calc_gvtd_after:
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
-    freq_filter:  # filter your data with a bandpass, hpf, or lpf
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
-      fmin: "0.01 Hz"  # set to 0 if you want a LPF
-      fmax: "0.5 Hz"  # set to 0 if you want a HPF
+      enable: true
+    tddr:
+      enable: false
+    freq_filter:
+      enable: false
+      fmin: "0.01 Hz"
+      fmax: "0.5 Hz"
     od2conc:
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+      enable: true
     plot_dqr:
-      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
-hrf_estimation:
-  stim_lst: ["STS_Q"]  # list of stims from events.tsv you want to estimate the HRF of
-  t_pre: "2 second"  # time before stim onset you want to model 
-  t_post: "35 second"  # time after stim onset you want to model
-  rec_str: "conc"  # conc or od_corrected  - what you want to block average
-  GLM:
-    enable: true  # if true do GLM, false do block averaging
-    do_drift: false  # if true, does normal drift correction, false does not
-    do_drift_legendre: true
-    do_short_sep: true
-    drift_order: 3
-    distance_threshold: "20 mm"
-    short_channel_method: "mean"
-    noise_model: "arirls"
+      enable: true
+
+hrf_estimation:   #  !!! make these constants instead?
+  rec_str: "conc"   
+  stim_lst: ["right", "left"]  #  make this in script instead of adding?  # auto but then add exlusion
+  t_pre: "2 second"   # can we make this a lsit for diff trial types for GLM
+  t_post: "10 second"
+  GLM:        
+   enable: true  # if true do GLM, false do block averaging
+   do_drift: "legendre" 
+   do_short_sep: true
+   drift_order: 3
+   distance_threshold: "20 mm"
+   short_channel_method : "mean"
+   noise_model: "ar_irls" 
+   basis_func: "gaussian_kernels"
+   basis_func_params:
     t_delta: "1 second"
     t_std: "1 second"
+
 groupaverage:
-  mse:    # for changing bad values IDed in prune channels mask. change vals for conc or od
-   mse_amp_thresh: 1e-3 
+  mse:   # conc
+   mse_amp_thresh: 1e-3 #1.1e-6 # amp vals below this thresh where we do not trust the variance estimate
    mse_val_for_bad_data: "1e7 micromolar**2"
    mse_min_thresh: "1e0 micromolar**2"
-   blockaverage_val: "0 micromolar**2"
-   hrf_val: "0 molar"
+   hrf_val: "0 micromolar"
   # mse:  # od
+  #  mse_amp_thresh: 1e-3 #1.1e-6
   #  mse_val_for_bad_data: 1e1
   #  mse_min_thresh: 1e-6
-  #  blockaverage_val: 0
+  #  hrf_val: 0
    
    
-image_recon:   # need to create sensitivity matrix first. Not included here yet.
-  mag:   
-    enable: false  # perform image recon on magnitude of HRF averaged between time window (t_win)
-    t_win: [5, 15]
-  DIRECT: 
-    enable: false  # true = direct, false = indirect
+image_recon:
+  generate_sensitivity: 
+    sub_folder: 'shannon'  # optional subfolder in /derivatives/cedalion/{folder}/probe/fw  # probe must be placed in folder/probe
+    forward_model: "MCX"  # MCX or NIRFASTER
+    head_model: 'icbm152'  # colin27, icbm152
+  mag:
+    enable: true
+    t_win: [5, 8]
+  recon_mode: "mua2conc"
   Cmeas: 
     enable: true
   BRAIN_ONLY:      # reconstruct brain only OR scalp and brain
@@ -88,23 +88,18 @@ image_recon:   # need to create sensitivity matrix first. Not included here yet.
     threshold_scalp: "5 mm"
     sigma_brain: "1 mm"
     sigma_scalp: "5 mm"
-  mse:  # od   - for changing bad values IDed in prune channels mask
-    mse_amp_thresh: 1e-3 #1.1e-6
+  noise_est_method: "posterior"
+  mse:  # od
     mse_val_for_bad_data: 1e1
     mse_min_thresh: 1e-6
     hrf_val: 0
-  probe_dir: "/projectnb/nphfnirs/s/datasets/Interactive_Walking_HD/derivatives/cedalion/probe/"
-  snirf_name_probe: "fullhead_56x144_NN22_System1.snirf"
-  head_model: 'ICBM152'
   alpha_meas: 1e4
-  alpha_spatial: 1e-3
+  alpha_spatial: 1e-3   #   (indirect: WITH SB= 1e-2, NO SB = 1e-3)
   spectrum: 'prahl'
+  lambda_spatial_depth: 1e-6   
 
-
-  
-  
-  
-  
-  
-  
-  
+  # plot_image:    
+  #   enable: false
+  #   flag_hbo_list: ['hbo', 'hbr']
+  #   flag_brain_list: ['brain', 'scalp']  # 'brain', 'scalp' - if you want to plot either
+  #   flag_img_list:  ['mag', 'tstat', 'noise']

--- a/workflow/config/config.yaml
+++ b/workflow/config/config.yaml
@@ -1,26 +1,20 @@
 dataset:
-  root_dir: "/projectnb/nphfnirs/s/users/shannon/Data/test_data_cedalion_smk/data" # where your BIDS data lives
-  derivatives_subfolder: "test_new_ced"  # where to save results. Saves as: derivatives/cedalion/YOURSTRING
-  #subject: ["586", "587", "592", "618", "621"]  # subject IDs you want to include. DO NOT INCL EXCLUDED SUBS
-  subjects_to_exclude: ["587", "618"]  # list of subjects you want to EXCLUDE.
-  task: ["BS"]  # task list. Currently only do ONE task at a time.                  
-  num_runs: 3
-
-  # runs_to_exclude:   # FIXME: add this option to scripts
-  #   "586": ["01"]  # dict of runs to exclude for each subject.
-  #   "621": ["02"]
-
+  root_dir: "/projectnb/nphfnirs/s/datasets/Interactive_Walking_HD"  # where your BIDS data lives
+  derivatives_subfolder: "cedalion/new_inclQ_first"  # where to save results. Saves as: derivatives/cedalion/
+  subject: ["01", "02", "03", "04", "05", "06", "07", "08"]  # subject IDs you want to include. DO NOT INCL EXCLUDED SUBS
+  task: ["STS"]  # task list. Currently only do ONE task at a time.                  
+  run: ["01"]  # number of runs for this task. 
 preprocess:
   steps:
     median_filter:  # process your data with a median filter
-      enable: true
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
       order: 1
     prune:
       enable: false  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
       snr_thresh: 5
       sd_thresh_min: "1 mm"
-      sd_thresh_max: "45 mm"  
-      amp_thresh_min: 1e-3
+      sd_thresh_max: "45 mm"
+      amp_thresh_min: "1e-3"
       amp_thresh_max: 0.84
       perc_time_clean_thresh: 0.6  # for sci x psp mask
       sci_threshold: 0.6
@@ -29,43 +23,48 @@ preprocess:
       flag_use_sci: true
       flag_use_psp: false
     int2od:
-      enable: true
-    # INSERT MA CORRECTION IF ANY HERE
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+    calc_slope_b4:  # calc slope before correction applied to od
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+    calc_gvtd_b4:  # calc gvtd before correction applied to od
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
     tddr:  # NOTE: can do other MA techniques instead. ie. splineSG, PCA_recurse, wavelet, 
-      enable: false
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+    calc_slope_after:
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+    calc_gvtd_after:
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
     freq_filter:  # filter your data with a bandpass, hpf, or lpf
-      enable: false
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
       fmin: "0.01 Hz"  # set to 0 if you want a LPF
-      fmax: "0.5 Hz"   # set to 0 if you want a HPF
+      fmax: "0.5 Hz"  # set to 0 if you want a HPF
     od2conc:
-      enable: true
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
     plot_dqr:
-      enable: true
-
-hrf_estimation:   #  !!! make these constants instead?
-  rec_str: "conc"   # MUST BE 'conc' OR 'od_02'    - what you want to block average
-  stim_lst: ["left", "right"]  # list of stims from events.tsv you want to estimate the HRF of
-  t_pre: "2 second"   # time before stim onset you want to model  #!!! can we make this a list for diff trial types for GLM
-  t_post: "10 second" # time after stim onset you want to model
-  GLM:        
-   enable: true  # if true do GLM, false do block averaging
-   do_drift: 'legendre'  # Options: None, 'polynomial', 'legendre'
-   drift_order: 3 
-   do_short_sep: true
-   distance_threshold: "20 mm"
-   short_channel_method : "mean"
-   noise_model: "ar_irls"    #  ols, rls, wls, ar_irls, gls, glsar
-   basis_func: "gaussian_kernels"
-   basis_func_params:
+      enable: true  # false, does not update timeseries but does return mask. false=weighted group average  # FIXME: have enable mean enable (mask created or not) and then add another flag for controlling timeseries
+hrf_estimation:
+  stim_lst: ["STS_Q"]  # list of stims from events.tsv you want to estimate the HRF of
+  t_pre: "2 second"  # time before stim onset you want to model 
+  t_post: "35 second"  # time after stim onset you want to model
+  rec_str: "conc"  # conc or od_corrected  - what you want to block average
+  GLM:
+    enable: true  # if true do GLM, false do block averaging
+    do_drift: false  # if true, does normal drift correction, false does not
+    do_drift_legendre: true
+    do_short_sep: true
+    drift_order: 3
+    distance_threshold: "20 mm"
+    short_channel_method: "mean"
+    noise_model: "arirls"
     t_delta: "1 second"
     t_std: "1 second"
-
-
 groupaverage:
   mse:    # for changing bad values IDed in prune channels mask. change vals for conc or od
+   mse_amp_thresh: 1e-3 
    mse_val_for_bad_data: "1e7 micromolar**2"
    mse_min_thresh: "1e0 micromolar**2"
-   hrf_val: "0 micromolar"
+   blockaverage_val: "0 micromolar**2"
+   hrf_val: "0 molar"
   # mse:  # od
   #  mse_val_for_bad_data: 1e1
   #  mse_min_thresh: 1e-6
@@ -73,14 +72,11 @@ groupaverage:
    
    
 image_recon:   # need to create sensitivity matrix first. Not included here yet.
-  generate_sensitivity: 
-    sub_folder: 'shannon'  # optional subfolder in /derivatives/cedalion/{folder}/probe/fw  # probe must be placed in folder/probe
-    forward_model: "MCX"  # MCX or NIRFASTER
-    head_model: 'icbm152'
   mag:   
-    enable: true  # perform image recon on magnitude of HRF averaged between time window (t_win)
-    t_win: [5, 8]
-  recon_mode: "mua2conc"
+    enable: false  # perform image recon on magnitude of HRF averaged between time window (t_win)
+    t_win: [5, 15]
+  DIRECT: 
+    enable: false  # true = direct, false = indirect
   Cmeas: 
     enable: true
   BRAIN_ONLY:      # reconstruct brain only OR scalp and brain
@@ -92,21 +88,17 @@ image_recon:   # need to create sensitivity matrix first. Not included here yet.
     threshold_scalp: "5 mm"
     sigma_brain: "1 mm"
     sigma_scalp: "5 mm"
-  noise_est_method: "posterior"   # posterior or measurement are options
-  mse:    # od   - for changing bad values IDed in prune channels mask
+  mse:  # od   - for changing bad values IDed in prune channels mask
+    mse_amp_thresh: 1e-3 #1.1e-6
     mse_val_for_bad_data: 1e1
     mse_min_thresh: 1e-6
     hrf_val: 0
+  probe_dir: "/projectnb/nphfnirs/s/datasets/Interactive_Walking_HD/derivatives/cedalion/probe/"
+  snirf_name_probe: "fullhead_56x144_NN22_System1.snirf"
+  head_model: 'ICBM152'
   alpha_meas: 1e4
   alpha_spatial: 1e-3
   spectrum: 'prahl'
-  lambda_spatial_depth: 1e-6   # old val for od 1.6e-09  , now 1e-6 for both od and conc 
-  plot_image:    
-    enable: false
-    flag_hbo_list: ['hbo', 'hbr']
-    flag_brain_list: ['brain', 'scalp']  # 'brain', 'scalp' - if you want to plot either
-    flag_img_list:  ['mag', 'tstat', 'noise']
-
 
 
   

--- a/workflow/scripts/generate_sensitivity_matrix.py
+++ b/workflow/scripts/generate_sensitivity_matrix.py
@@ -36,7 +36,9 @@ def generate_Adot_func(cfg_Adot, root_dir, sub, head_model, save_dir_Adot):
     fluence_fname = os.path.join(save_dir_fl, "fluence.h5")
 
     if cfg_Adot['forward_model'] == "MCX":
-        fwm.compute_fluence_mcx(fluence_fname)
+        fwm.compute_fluence_mcx(fluence_fname, cuda=True)
+    elif cfg_Adot['forward_model'] == "MCXCL":
+        fwm.compute_fluence_mcx(fluence_fname, cuda=False)
     elif cfg_Adot['forward_model'] == "NIRFASTER":
         fwm.compute_fluence_nirfaster(fluence_fname)
 

--- a/workflow/scripts/homer/homer.py
+++ b/workflow/scripts/homer/homer.py
@@ -1,0 +1,241 @@
+#%% Import necessary libraries
+import os
+import re
+import pickle
+import gzip
+import time_series_gui
+from tkinter import filedialog
+import tkinter as tk
+#%% Define paths and extract data information
+# Smart path selection logic
+current_dir = os.getcwd()
+
+# Get root_dir (BIDS dataset root) and derivatives path
+root_dir = current_dir
+derivatives_path = os.path.join(current_dir, 'derivatives')
+cedalion_path = os.path.join(derivatives_path, 'cedalion')
+path_to_data = None
+initial_dir = current_dir
+title = "Select the data directory"
+
+# Check if 'derivatives/cedalion' path exists
+if os.path.isdir(cedalion_path):
+    # List subdirectories
+    subfolders = [d for d in os.listdir(cedalion_path) if os.path.isdir(os.path.join(cedalion_path, d))]
+    
+    # if len(subfolders) == 1:
+    #     # If only one folder, use it automatically
+    #     path_to_data = os.path.join(cedalion_path, subfolders[0])
+    #     print(f"Automatically selected data directory: {path_to_data}")
+    # else:
+    # If multiple or zero folders, set initial directory to cedalion_path
+
+    initial_dir = cedalion_path
+    title = "Select data directory from 'derivatives/cedalion'"
+
+# If path_to_data was not automatically set, open the file dialog
+if path_to_data is None:
+    print("\n" + "="*70)
+    print("📁 FOLDER SELECTION DIALOG OPENED")
+    print("="*70)
+    print("Please select the data directory from the dialog window.")
+    print("(The dialog window may be in the background - check your taskbar)")
+    print("="*70 + "\n")
+    
+    root = tk.Tk() 
+    root.withdraw()  # Hide the main window
+    path_to_data = filedialog.askdirectory(
+        title=title,
+        initialdir=initial_dir
+    )
+    root.destroy()
+
+    # Check if user cancelled the dialog
+    if not path_to_data:
+        print("No directory selected. Exiting...")
+        exit()
+
+print(f"Using data directory: {path_to_data}")
+
+# Derive root_dir (BIDS dataset root) from the selected path
+# Navigate up from path_to_data to find the BIDS root (where sub-XX folders are)
+# Typical structure: /path/to/dataset/derivatives/cedalion/pipeline_name
+# BIDS root should be: /path/to/dataset/
+path_parts = os.path.normpath(path_to_data).split(os.sep)
+if 'derivatives' in path_parts:
+    # Find index of 'derivatives' and go up to get BIDS root
+    derivatives_idx = path_parts.index('derivatives')
+    root_dir = os.sep.join(path_parts[:derivatives_idx])
+else:
+    # Fallback: assume path_to_data is already close to root, go up a few levels
+    root_dir = os.path.dirname(os.path.dirname(path_to_data))
+
+print(f"Derived BIDS root directory: {root_dir}")
+
+# Construct the path to the preprocessed data
+if os.path.basename(path_to_data) == 'preprocessed_data':
+    preprocessed_path = path_to_data
+else:
+    preprocessed_path = os.path.join(path_to_data, 'preprocessed_data')
+
+# List to store the extracted information
+all_data_info = []
+
+# Scan for SNIRF files in root_dir
+print(f"Scanning for SNIRF files in: {root_dir}")
+
+for subject_folder in os.listdir(root_dir):
+    if subject_folder.startswith('sub-'):
+        subject_path = os.path.join(root_dir, subject_folder)
+        if not os.path.isdir(subject_path):
+            continue
+
+        subject_name = subject_folder.replace('sub-', '')
+        
+        # Check for session folders
+        session_folders = [d for d in os.listdir(subject_path) 
+                          if d.startswith('ses-') and os.path.isdir(os.path.join(subject_path, d))]
+
+        if session_folders:
+            # Sessions exist, iterate through them
+            for session_folder in session_folders:
+                session_path = os.path.join(subject_path, session_folder)
+                session_name = session_folder.replace('ses-', '')
+                
+                # Look for nirs folder
+                nirs_path = os.path.join(session_path, 'nirs')
+                if os.path.isdir(nirs_path):
+                    for filename in os.listdir(nirs_path):
+                        if filename.endswith('.snirf'):
+                            # Extract task and run from filename
+                            task_match = re.search(r'task-([^_]+)', filename)
+                            run_match = re.search(r'run-([^_]+)', filename)
+                            
+                            task_name = task_match.group(1) if task_match else None
+                            run_name = run_match.group(1) if run_match else None
+                            
+                            snirf_file_path = os.path.join(nirs_path, filename)
+                            
+                            # Construct expected preprocessed SNIRF path
+                            pkl_filename = snirf_filename.replace('.snirf', '_preprocessed.snirf')
+                            if session_folder:
+                                pkl_path = os.path.join(preprocessed_path, subject_folder, session_folder, pkl_filename)
+                            else:
+                                pkl_path = os.path.join(preprocessed_path, subject_folder, pkl_filename)
+                            
+                            # Check if pkl exists
+                            pkl_exists = os.path.exists(pkl_path) if preprocessed_path else False
+                            
+                            all_data_info.append({
+                                'subject': subject_name,
+                                'session': session_name,
+                                'task': task_name,
+                                'run': run_name,
+                                'snirf_path': snirf_file_path,
+                                'pkl_path': pkl_path if pkl_exists else None
+                            })
+        else:
+            # No sessions, look for nirs folder directly in subject folder
+            nirs_path = os.path.join(subject_path, 'nirs')
+            if os.path.isdir(nirs_path):
+                for filename in os.listdir(nirs_path):
+                    if filename.endswith('.snirf'):
+                        # Extract task and run from filename
+                        task_match = re.search(r'task-([^_]+)', filename)
+                        run_match = re.search(r'run-([^_]+)', filename)
+                        
+                        task_name = task_match.group(1) if task_match else None
+                        run_name = run_match.group(1) if run_match else None
+                        
+                        snirf_file_path = os.path.join(nirs_path, filename)
+                        
+                        # Construct expected preprocessed SNIRF path
+                        pkl_filename = filename.replace('.snirf', '_preprocessed.snirf')
+                        pkl_path = os.path.join(preprocessed_path, subject_folder, pkl_filename)
+                        
+                        print(f"DEBUG homer.py: SNIRF file: {filename}")
+                        print(f"DEBUG homer.py: PKL filename: {pkl_filename}")
+                        print(f"DEBUG homer.py: PKL path: {pkl_path}")
+                        print(f"DEBUG homer.py: PKL exists: {os.path.exists(pkl_path) if preprocessed_path else False}")
+                        
+                        # Check if pkl exists
+                        pkl_exists = os.path.exists(pkl_path) if preprocessed_path else False
+                        
+                        all_data_info.append({
+                            'subject': subject_name,
+                            'session': None,
+                            'task': task_name,
+                            'run': run_name,
+                            'snirf_path': snirf_file_path,
+                            'pkl_path': pkl_path if pkl_exists else None
+                        })
+
+# Create combined labels and a file map
+file_map = {}
+combined_subjects_set = set()
+
+# This dictionary will map combined subject labels to a set of their available combined run labels
+subject_to_runs_map = {}
+
+print(f"Found {len(all_data_info)} SNIRF files")
+
+for info in all_data_info:
+    # Create combined subject label
+    subject_part = f"sub-{info['subject']}"
+    session_part = f"ses-{info['session']}" if info['session'] else None
+    combined_subject = f"{subject_part}_{session_part}" if session_part else subject_part
+    combined_subjects_set.add(combined_subject)
+
+    # Create combined run label
+    run_part = f"run-{info['run']}" if info['run'] else None
+    task_part = f"task-{info['task']}" if info['task'] else None
+    
+    if run_part and task_part:
+        combined_run = f"{task_part}_{run_part}"
+    elif run_part:
+        combined_run = run_part
+    elif task_part:
+        combined_run = task_part
+    else:
+        combined_run = 'default' # Fallback
+
+    # Populate the file_map and the subject_to_runs_map
+    if combined_subject not in file_map:
+        file_map[combined_subject] = {}
+        subject_to_runs_map[combined_subject] = set()
+
+    # Store both SNIRF and PKL paths
+    file_map[combined_subject][combined_run] = {
+        'snirf_path': info['snirf_path'],
+        'pkl_path': info['pkl_path']
+    }
+    subject_to_runs_map[combined_subject].add(combined_run)
+    
+    if info['pkl_path']:
+        print(f"  {combined_subject}/{combined_run}: SNIRF + PKL")
+    else:
+        print(f"  {combined_subject}/{combined_run}: SNIRF only (no processed data)")
+
+# Convert sets to sorted lists for stable ordering in the GUI
+subjects = sorted(list(combined_subjects_set))
+for subj in subject_to_runs_map:
+    subject_to_runs_map[subj] = sorted(list(subject_to_runs_map[subj]))
+
+
+print("Combined Subjects:", subjects)
+print("Subject to Runs Map:", subject_to_runs_map)
+
+# Create a dictionary to pass to the GUI
+gui_data = {
+    "subjects": subjects,
+    "subject_to_runs_map": subject_to_runs_map,
+    "file_map": file_map,
+    "path_to_data": path_to_data  # Pass the selected derivatives/cedalion/XXX folder
+}
+
+# Visualize the data
+if all_data_info:
+    print("Starting visualization...")
+    time_series_gui.run_vis(gui_data)
+else:
+    print("No SNIRF files found to process.")    

--- a/workflow/scripts/homer/plot_probe_gui.py
+++ b/workflow/scripts/homer/plot_probe_gui.py
@@ -1,0 +1,823 @@
+"""Interactive GUI to view the HRF in probe space after data has been processed.
+
+Based on Homer3 v1.80.2 "PlotProbe2.m" (:cite:t:`Huppert2009`)
+    Boston University Neurophotonics Center
+    https://github.com/BUNPC/Homer3
+
+Initial Contributors:
+    - Sung Ahn | ahnsm@bu.edu | 2024
+"""
+
+from __future__ import annotations
+import sys
+import time
+import warnings
+
+import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvas
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.backends.qt_compat import QtWidgets, QtGui, QtCore
+from matplotlib.figure import Figure
+
+import cedalion
+import cedalion.typing as cdt
+
+warnings.simplefilter("ignore")
+
+
+class _MAIN_GUI(QtWidgets.QMainWindow):
+    def __init__(self, snirfData=None, stderr=None, geo2d=None, geo3d=None):
+        # Initialize
+        super().__init__()
+        self.snirfData = snirfData
+        self.stderr = stderr  
+        self.geo2d = geo2d
+        self.geo3d = geo3d
+
+        # Set central widget
+        self._main = QtWidgets.QWidget()
+        self.setCentralWidget(self._main)
+
+        # Initialize layout (horizontal to place plot on left, controls on right)
+        window_layout = QtWidgets.QHBoxLayout(self._main)
+        window_layout.setContentsMargins(10, 0, 10, 10)
+        window_layout.setSpacing(10)
+
+        # Set Minimum Size
+        self.setMinimumSize(800, 600)
+
+        # Set Window Title
+        self.setWindowTitle("Plot Probe")
+
+        # Create left panel for plot and toolbar
+        plot_panel = QtWidgets.QWidget()
+        plot_panel_layout = QtWidgets.QVBoxLayout(plot_panel)
+        plot_panel_layout.setContentsMargins(0, 0, 0, 0)
+        plot_panel_layout.setSpacing(5)
+
+        # Filler plot for now
+        self.plotprobe = FigureCanvas(Figure(figsize=(10, 10)))
+        self._ax = self.plotprobe.figure.subplots()
+        self._ax.axis("off")
+        plot_panel_layout.addWidget(NavigationToolbar(self.plotprobe, self), stretch=0)
+        plot_panel_layout.addWidget(self.plotprobe, stretch=1)
+        
+        # Add plot panel to main window (left side)
+        window_layout.addWidget(plot_panel, stretch=8)
+
+        # Create Control Panel (vertical layout for all controls)
+        control_panel = QtWidgets.QWidget()
+        control_panel_layout = QtWidgets.QVBoxLayout(control_panel)
+        control_panel_layout.setContentsMargins(5, 0, 5, 0)
+        control_panel_layout.setSpacing(10)
+        control_panel_layout.setAlignment(QtCore.Qt.AlignTop)
+        
+        # Add control panel to main window (right side)
+        window_layout.addWidget(control_panel, stretch=2)
+
+        # Create Activity Display Controls
+        display_activity = QtWidgets.QGroupBox("Display Activity")
+        display_activity.setMaximumHeight(180)  # Limit overall height
+        display_activity_layout = QtWidgets.QVBoxLayout()
+        display_activity.setLayout(display_activity_layout)
+
+        ## Condition Selector
+        self.conditions = QtWidgets.QListWidget()
+        self.conditions.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.conditions.insertItem(0, "-- Select Condition --")
+        self.conditions.currentTextChanged.connect(self._condition_changed)
+        self.conditions.setMaximumHeight(150)  # Reduce height to half
+        display_activity_layout.addWidget(self.conditions)
+
+        ## Add Display Activity
+        control_panel_layout.addWidget(display_activity)
+
+        # Create Plot Scale Controls
+        plot_scale = QtWidgets.QGroupBox("Plot Scale")
+        plot_scale_layout = QtWidgets.QVBoxLayout()
+        plot_scale_layout.setSpacing(15)
+        plot_scale.setLayout(plot_scale_layout)
+
+        ## X Scaler
+        x_scale_layout = QtWidgets.QHBoxLayout()
+        self.x_scale = QtWidgets.QDoubleSpinBox()
+        self.x_scale.setValue(1)
+        self.x_scale.setSingleStep(0.2)
+        self.x_scale.valueChanged.connect(self._xscale_changed)
+        x_scale_layout.addWidget(QtWidgets.QLabel("X scale"))
+        x_scale_layout.addWidget(self.x_scale)
+        plot_scale_layout.addLayout(x_scale_layout)
+
+        ## Y Scaler
+        y_scale_layout = QtWidgets.QHBoxLayout()
+        self.y_scale = QtWidgets.QDoubleSpinBox()
+        self.y_scale.setValue(1)
+        self.y_scale.setSingleStep(0.2)
+        self.y_scale.valueChanged.connect(self._yscale_changed)
+        y_scale_layout.addWidget(QtWidgets.QLabel("Y scale"))
+        y_scale_layout.addWidget(self.y_scale)
+        plot_scale_layout.addLayout(y_scale_layout)
+
+        ## Add Scaler
+        control_panel_layout.addWidget(plot_scale)
+
+        # Create Prune Channels Control
+        prune_channels = QtWidgets.QGroupBox("Prune Channels")
+        prune_channels_layout = QtWidgets.QGridLayout()
+        prune_channels_layout.setSpacing(10)
+        prune_channels.setLayout(prune_channels_layout)
+
+        ## Set up Prune Channels controllers
+        self.mindist = QtWidgets.QDoubleSpinBox()
+        self.mindist.setValue(15)
+        self.mindist.setSingleStep(3)
+        self.mindist.valueChanged.connect(self._mindist_changed)
+        self.maxdist = QtWidgets.QDoubleSpinBox()
+        self.maxdist.setValue(45)
+        self.mindist.setRange(15, self.maxdist.value())
+        self.maxdist.setRange(self.mindist.value(), 45)
+        self.maxdist.setSingleStep(3)
+        self.maxdist.valueChanged.connect(self._maxdist_changed)
+        self.ssfade = QtWidgets.QDoubleSpinBox()
+        self.ssfade.setValue(15)
+        self.ssfade.setRange(15, 45)
+        self.ssfade.setSingleStep(3)
+        self.ssfade.valueChanged.connect(self._ssfade_changed)
+
+        ## Populate Prune Channels
+        prune_channels_layout.addWidget(QtWidgets.QLabel("Min dist"), 0, 0)
+        prune_channels_layout.addWidget(self.mindist, 0, 1)
+        prune_channels_layout.addWidget(QtWidgets.QLabel("Max dist"), 1, 0)
+        prune_channels_layout.addWidget(self.maxdist, 1, 1)
+        prune_channels_layout.addWidget(QtWidgets.QLabel("SS fade thresh"), 2, 0)
+        prune_channels_layout.addWidget(self.ssfade, 2, 1)
+        
+        # Add T-stat threshold (only if standard error is provided)
+        if self.stderr is not None:
+            self.tstat_threshold = QtWidgets.QDoubleSpinBox()
+            self.tstat_threshold.setValue(0)  # Default: no threshold
+            self.tstat_threshold.setRange(-100, 100)
+            self.tstat_threshold.setSingleStep(0.5)
+            self.tstat_threshold.setDecimals(2)
+            self.tstat_threshold.editingFinished.connect(self._tstat_threshold_changed)
+            prune_channels_layout.addWidget(QtWidgets.QLabel("T-stat"), 3, 0)
+            prune_channels_layout.addWidget(self.tstat_threshold, 3, 1)
+            
+            # Add std_err threshold
+            self.stderr_threshold = QtWidgets.QDoubleSpinBox()
+            self.stderr_threshold.setRange(0, 1e10)  # Set range first
+            self.stderr_threshold.setValue(1e6)  # Default: 1e6
+            self.stderr_threshold.setSingleStep(0.1)
+            self.stderr_threshold.setDecimals(8)
+            self.stderr_threshold.editingFinished.connect(self._stderr_threshold_changed)
+            prune_channels_layout.addWidget(QtWidgets.QLabel("std_err"), 4, 0)
+            prune_channels_layout.addWidget(self.stderr_threshold, 4, 1)
+
+        ## Add Prune Channels
+        control_panel_layout.addWidget(prune_channels)
+
+        # Create Probe Control
+        probe_control = QtWidgets.QGroupBox("Probe")
+        probe_control_layout = QtWidgets.QVBoxLayout()
+        probe_control_layout.setSpacing(5)
+        probe_control.setLayout(probe_control_layout)
+
+        ## Set up Probe Control controllers
+        self.opt2circ = QtWidgets.QCheckBox("View optodes as circles")
+        self.opt2circ.stateChanged.connect(self._toggle_circles)
+        self.measline = QtWidgets.QCheckBox("Display Measurement Line")
+        self.measline.stateChanged.connect(self._toggle_measline)
+
+        # sigact = QtWidgets.QCheckBox("Display significant activation")
+        # pval = QtWidgets.QLineEdit()
+        # pval.setInputMask('0.00;_')
+        # pval.setText("0.05")
+
+        ## Populate Probe Control
+        probe_control_layout.addWidget(self.opt2circ)
+        probe_control_layout.addWidget(self.measline)
+        # probe_control_layout.addWidget(sigact)
+        pval_layout = QtWidgets.QHBoxLayout()
+        pval_layout.setSpacing(10)
+        # pval_layout.addWidget(QtWidgets.QLabel("p-val level of sig"))
+        # pval_layout.addWidget(pval)
+        probe_control_layout.addLayout(pval_layout)
+
+        ## Add Probe Control
+        control_panel_layout.addWidget(probe_control)
+
+        # # Create Reference Points Control
+        # ref_point = QtWidgets.QGroupBox("Reference Points")
+        # ref_point_layout = QtWidgets.QVBoxLayout()
+        # ref_point_layout.setSpacing(10)
+        # ref_point.setLayout(ref_point_layout)
+
+        # ## Set up and populate selectors
+        # label_btn = QtWidgets.QRadioButton("Labels")
+        # circ_btn = QtWidgets.QRadioButton("Circles")
+        # ref_point_layout.addWidget(label_btn,stretch=1)
+        # ref_point_layout.addWidget(circ_btn,stretch=1)
+        # # ref_point_layout.addWidget(QtWidgets.QLabel(),stretch=2)
+
+        # ## Add Reference Points Control
+        # control_panel_layout.addWidget(ref_point,stretch=1)
+
+        # Create button action for opening file
+        open_btn = QtGui.QAction("Open...", self)
+        open_btn.setStatusTip("Open SNIRF file")
+        open_btn.triggered.connect(self._open_dialog)
+
+        ## Create menu
+        menu = QtWidgets.QMenuBar(self)
+        self.setMenuBar(menu)
+
+        ## Populate menu
+        file_menu = menu.addMenu("&File")
+        file_menu.addAction(open_btn)
+
+        if self.snirfData is not None:
+            time_dim = 'reltime' if 'reltime' in self.snirfData.dims else 'time' # Detect time dimension
+            if np.shape(self.snirfData)[1] != len(self.snirfData.channel):
+                self.snirfData = self.snirfData.transpose(
+                    "trial_type", "channel", "chromo", time_dim
+                )
+
+            self.sPos = self.geo2d.sel(
+                label=["S" in s for s in self.geo2d.label.values]
+            )
+            self.dPos = self.geo2d.sel(
+                label=["D" in s for s in self.geo2d.label.values]
+            )
+
+            self.sourcePos3D = self.geo3d.sel(
+                label=["S" in str(s.values) for s in self.geo3d.label]
+            )
+            self.detectorPos3D = self.geo3d.sel(
+                label=["D" in str(s.values) for s in self.geo3d.label]
+            )
+
+            print("starting calculations!")
+            self._init_calc()
+
+    def _open_dialog(self):
+        # Grab the appropriate SNIRF file
+        self._fname = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Open File",
+            "${HOME}",
+            "SNIRF Files (*.snirf)",
+        )[0]
+        print("Loading SNIRF...")
+        t0 = time.time()
+        self.snirfObj = cedalion.io.read_snirf(self._fname)
+        t1 = time.time()
+        print(f"SNIRF Loaded in {t1 - t0:.2f} seconds!")
+
+        # Extract necessary data
+        self.snirfData = self.snirfObj[0].data[0]
+
+        self.sPos = self.snirfObj[0].geo2d.sel(
+            label=["S" in str(s.values) for s in self.snirfObj[0].geo2d.label]
+        )
+        self.dPos = self.snirfObj[0].geo2d.sel(
+            label=["D" in str(s.values) for s in self.snirfObj[0].geo2d.label]
+        )
+
+        self.sourcePos3D = self.snirfObj[0].geo3d.sel(
+            label=["S" in str(s.values) for s in self.snirfObj[0].geo3d.label]
+        )
+        self.detectorPos3D = self.snirfObj[0].geo3d.sel(
+            label=["D" in str(s.values) for s in self.snirfObj[0].geo3d.label]
+        )
+
+        self._init_calc()
+
+    def _init_calc(self):
+        t0 = time.time()
+
+        # Initialize certain values to begin
+        self.x_scale.setValue(1)
+        self.plot_Xscale = 1
+        self.x_scale.setValue(1)
+        self.plot_Yscale = 1
+
+        self.mindist.setValue(15)
+        self.channel_min_dist = 15
+        self.maxdist.setValue(45)
+        self.channel_max_dist = 45
+        self.ssfade.setValue(15)
+        self.ssFadeThres = 15
+        self.fade_factor = 0.3  ##### Connect?
+        self.lineWidth = 0.7  ##### Connect?
+
+        if 'reltime' in self.snirfData.dims: # handle 'time' or 'reltime'
+            self.time_dim = 'reltime'
+        elif 'time' in self.snirfData.dims:
+            self.time_dim = 'time'
+        else:
+            raise ValueError("Data must have either 'time' or 'reltime' dimension")
+
+
+        # T-stat and stderr calculation
+        self.tstat_thresh = 0  # Initialize threshold
+        self.stderr_thresh = 1e6  # Initialize stderr threshold
+        if self.stderr is not None:
+            # Calculate t-statistic: mean / stderr
+            self.tstat = self.snirfData / self.stderr
+            # Get max absolute t-stat per channel across time for thresholding
+            self.tstat_max = np.abs(self.tstat).max(dim=self.time_dim)  # Max across time
+            # Get mean stderr per channel across time for thresholding
+            self.stderr_mean = self.stderr.mean(dim=self.time_dim)  # Mean across time
+        else:
+            self.tstat = None
+            self.tstat_max = None
+            self.stderr_mean = None
+
+        self.conditions.clear()
+        self.opt2circ.setChecked(False)
+        self.measline.setChecked(False)
+
+        # Color for conditions
+        self.color_HbO = [0.862, 0.078, 0.235]  ##### Connect?
+        self.color_HbR = [0, 0, 0.8]  ##### Connect?
+        self.chrom = {0: self.color_HbO, 1: self.color_HbR}
+
+        self.sPosVal = self.sPos.values
+        self.dPosVal = self.dPos.values
+
+        self.src_idx = [
+            np.arange(0, len(self.sPos))[self.sPos.label == src][0]
+            for src in self.snirfData.source
+        ]
+        self.det_idx = [
+            np.arange(0, len(self.dPos))[self.dPos.label == det][0]
+            for det in self.snirfData.detector
+        ]
+
+        # Find Channel distances
+        self.chan_dist = np.sqrt(
+            np.sum(
+                (
+                    self.sourcePos3D.values[self.src_idx]
+                    - self.detectorPos3D.values[self.det_idx]
+                )
+                ** 2,
+                1,
+            )
+        )
+
+        # Find the extreme coordinates of the optodes
+        self.sdMin = np.array(
+            [
+                min([min(self.sPos[:, 0]), min(self.dPos[:, 0])]).values,
+                min([min(self.sPos[:, 1]), min(self.dPos[:, 1])]).values,
+            ]
+        )
+        self.sdMin = self.sdMin - np.mean(self.chan_dist)
+        self.sdMax = np.array(
+            [
+                max([max(self.sPos[:, 0]), max(self.dPos[:, 0])]).values,
+                max([max(self.sPos[:, 1]), max(self.dPos[:, 1])]).values,
+            ]
+        )
+        self.sdMax = self.sdMax + np.mean(self.chan_dist)
+
+        # Find the scaling factors for the plot
+        self.sdWid = self.sdMax[0] - self.sdMin[0]
+        self.sdHgt = self.sdMax[1] - self.sdMin[1]
+
+        # Find the axis scale
+        self.sd2axScl = max(self.sdWid, self.sdHgt)
+
+        # Scale the optode coordinates by the scale
+        self.sPosVal /= self.sd2axScl
+        self.dPosVal /= self.sd2axScl
+
+        # Calculate the scaling/translation factors
+        self.nAcross = (
+            len(np.unique(np.append(self.sPosVal, self.dPosVal, axis=0)[:, 0])) + 1
+        )
+        self.axXoff = np.mean(np.append(self.sPosVal, self.dPosVal, axis=0)[:, 0]) - 0.5
+        self.nUp = (
+            len(np.unique(np.append(self.sPosVal, self.dPosVal, axis=0)[:, 1])) + 1
+        )
+        self.axYoff = np.mean(np.append(self.sPosVal, self.dPosVal, axis=0)[:, 1]) - 0.5
+
+        # Calculate the size of each HRF
+        self.axWid = self.plot_Xscale / self.nAcross
+        self.axHgt = self.plot_Yscale / self.nUp
+
+        # Extract the x-y coordinates of the optodes
+        self.sx = self.sPosVal[:, 0] - self.axXoff
+        self.sy = self.sPosVal[:, 1] - self.axYoff
+        self.dx = self.dPosVal[:, 0] - self.axXoff
+        self.dy = self.dPosVal[:, 1] - self.axYoff
+
+        # Extract time information
+        try:
+            self.t = self.snirfData[self.time_dim].values  # CHANGE to use self.time_dim
+        except Exception:
+            # Fallback to trying both
+            try:
+                self.t = self.snirfData.time.values
+            except Exception:
+                self.t = self.snirfData.reltime.values
+        # try:
+        #     self.t = self.snirfData.time.values
+        # except Exception:
+        #     pass
+        # try:
+        #     self.t = self.snirfData.reltime.values
+        # except Exception:
+        #     pass
+
+        self.minT = min(self.t)
+        self.maxT = max(self.t)
+
+        # Extract lengths
+        self.trial_types = len(self.snirfData.trial_type)
+        self.channels = len(self.snirfData.channel)
+        self.chromophores = len(self.snirfData.chromo)
+
+        # Initialize holders to control each part of the plot
+        self.src_label = [0] * len(self.sx)
+        self.det_label = [0] * len(self.dx)
+        self.meas_line = [0] * self.channels
+        self.hrf = (
+            [0] * self.chromophores * self.channels * self.trial_types
+        )  # access via: condition*no_chans + channel*no_chrom + chromophore
+
+        # Calculate the HRF plot coordinates
+        self.xa = (self.sx[self.src_idx] + self.dx[self.det_idx]) / 2
+        self.ya = (self.sy[self.src_idx] + self.dy[self.det_idx]) / 2
+        self.hrf_val = [
+            self.snirfData.sel(trial_type=i).values for i in self.snirfData.trial_type
+        ]
+        self.ya = np.array([[[a] * len(self.t)] * self.chromophores for a in self.ya])
+
+        self.cmin = [0] * self.trial_types
+        self.cmax = [0] * self.trial_types
+
+        for trial in range(self.trial_types):
+            self.cmin[trial] = np.min(np.nan_to_num(self.hrf_val[trial].ravel(), 10))
+            self.cmax[trial] = np.max(np.nan_to_num(self.hrf_val[trial].ravel(), -10))
+
+        self.cmin = min(self.cmin)
+        self.cmax = max(self.cmax)
+
+        self.xT = [
+            xa1
+            - self.axWid / 8
+            + (1 / 4) * self.axWid * ((self.t - self.minT) / (self.maxT - self.minT))
+            for xa1 in self.xa
+        ]
+        self.hrfT = [
+            0
+        ] * self.trial_types  # access via: condition, channel, chromophore
+        for trial in range(self.trial_types):
+            self.hrfT[trial] = (
+                self.ya
+                - self.axHgt / 8
+                + (1 / 4)
+                * self.axHgt
+                * ((self.hrf_val[trial] - self.cmin) / (self.cmax - self.cmin))
+            )
+
+        # Update Conditions in list widget
+        for tidx, trial in enumerate(self.snirfData.trial_type.values):
+            self.conditions.insertItem(tidx, str(trial))
+
+        t1 = time.time()
+        print(f"Calculations complete in {t1-t0:.2f} seconds!")
+        self._draw_hrf()
+        self.conditions.setCurrentRow(0)
+
+    # def _change_hrf_vis(self):  # orig
+    #     for i_con in range(self.trial_types):
+    #         if i_con == self.conditions.currentRow():
+    #             for i_ch in range(self.channels):
+    #                 if (
+    #                     self.chan_dist[i_ch] >= self.channel_min_dist
+    #                     and self.chan_dist[i_ch] <= self.ssFadeThres
+    #                 ):
+    #                     for i_col in range(self.chromophores):
+    #                         self.hrf[
+    #                             i_con * self.channels * self.chromophores
+    #                             + i_ch * self.chromophores
+    #                             + i_col
+    #                         ].set_color(self.chrom[i_col] + [self.fade_factor])
+    #                 elif (
+    #                     self.chan_dist[i_ch] >= self.ssFadeThres
+    #                     and self.chan_dist[i_ch] <= self.channel_max_dist
+    #                 ):
+    #                     for i_col in range(self.chromophores):
+    #                         self.hrf[
+    #                             i_con * self.channels * self.chromophores
+    #                             + i_ch * self.chromophores
+    #                             + i_col
+    #                         ].set_color(self.chrom[i_col] + [1])
+    #                 else:
+    #                     for i_col in range(self.chromophores):
+    #                         self.hrf[
+    #                             i_con * self.channels * self.chromophores
+    #                             + i_ch * self.chromophores
+    #                             + i_col
+    #                         ].set_color(self.chrom[i_col] + [0])
+    #         else:
+    #             for i_ch in range(self.channels):
+    #                 for i_col in range(self.chromophores):
+    #                     self.hrf[
+    #                         i_con * self.channels * self.chromophores
+    #                         + i_ch * self.chromophores
+    #                         + i_col
+    #                     ].set_color(self.chrom[i_col] + [0])
+
+    #     self._ax.figure.canvas.draw()
+    
+    def _change_hrf_vis(self):
+        for i_con in range(self.trial_types):
+            if i_con == self.conditions.currentRow():
+                for i_ch in range(self.channels):
+                    # Determine alpha based on distance first
+                    if (
+                        self.chan_dist[i_ch] >= self.channel_min_dist
+                        and self.chan_dist[i_ch] <= self.ssFadeThres
+                    ):
+                        base_alpha = self.fade_factor
+                    elif (
+                        self.chan_dist[i_ch] >= self.ssFadeThres
+                        and self.chan_dist[i_ch] <= self.channel_max_dist
+                    ):
+                        base_alpha = 1
+                    else:
+                        base_alpha = 0
+                    
+                    # Apply t-stat fading and stderr pruning
+                    # T-stat: fade based on how far below threshold (like SS fade)
+                    # Stderr: hard cutoff (hide channel completely if above threshold)
+                    if base_alpha > 0 and self.tstat_max is not None and self.stderr_mean is not None:
+                        # Get max t-stat across all chromophores for this channel
+                        tstat_values = [
+                            self.tstat_max.sel(trial_type=self.snirfData.trial_type[i_con]).values[i_ch, i_col]
+                            for i_col in range(self.chromophores)
+                        ]
+                        max_tstat = max(tstat_values)
+                        
+                        # Fade based on t-stat (below threshold -> fade, above threshold -> full opacity)
+                        if self.tstat_thresh > 0:
+                            if max_tstat >= self.tstat_thresh:
+                                # Above threshold: full opacity (no change to base_alpha)
+                                tstat_alpha = 1.0
+                            elif max_tstat >= self.tstat_thresh * 0.5:
+                                # Between 50% and 100% of threshold: fade proportionally
+                                tstat_alpha = self.fade_factor + (1.0 - self.fade_factor) * (max_tstat / self.tstat_thresh)
+                            else:
+                                # Below 50% of threshold: maximum fade
+                                tstat_alpha = self.fade_factor
+                            base_alpha *= tstat_alpha
+                        
+                        # Hard cutoff based on stderr (any chromophore exceeds threshold -> hide completely)
+                        stderr_values = [
+                            self.stderr_mean.sel(trial_type=self.snirfData.trial_type[i_con]).values[i_ch, i_col]
+                            for i_col in range(self.chromophores)
+                        ]
+                        if any(stderr_val > self.stderr_thresh for stderr_val in stderr_values):
+                            base_alpha = 0
+                    
+                    # Set color for each chromophore
+                    for i_col in range(self.chromophores):
+                        self.hrf[
+                            i_con * self.channels * self.chromophores
+                            + i_ch * self.chromophores
+                            + i_col
+                        ].set_color(self.chrom[i_col] + [base_alpha])
+            else:
+                for i_ch in range(self.channels):
+                    for i_col in range(self.chromophores):
+                        self.hrf[
+                            i_con * self.channels * self.chromophores
+                            + i_ch * self.chromophores
+                            + i_col
+                        ].set_color(self.chrom[i_col] + [0])
+
+        self._ax.figure.canvas.draw()
+
+    def _re_draw_hrf(self):
+        for i_con in range(self.trial_types):
+            for i_ch in range(self.channels):
+                for i_col in range(self.chromophores):
+                    self.hrf[
+                        i_con * self.channels * self.chromophores
+                        + i_ch * self.chromophores
+                        + i_col
+                    ].set_data(self.xT[i_ch], self.hrfT[i_con][i_ch][i_col])
+
+        self._ax.figure.canvas.draw()
+
+    def _condition_changed(self, s):
+        # Pass the new condition and draw hrf again
+        if self.conditions.currentItem() is None:
+            pass
+        elif self.conditions.currentItem().text() == "-- Select Condition --":
+            pass
+        else:
+            self._change_hrf_vis()
+
+    def _toggle_circles(self):
+        if self.opt2circ.isChecked():
+            self.src_optodes.set_color([1, 0, 0])
+            self.det_optodes.set_color([0, 0, 1])
+            self.src_optodes.set_markersize(3)  # ADD THIS - Make circles smaller
+            self.det_optodes.set_markersize(3)  # ADD THIS - Make circles smaller
+
+            for idx, source in enumerate(self.sPos.label):
+                self.src_label[idx].set_color([1, 0, 0, 0])
+            for idx, detector in enumerate(self.dPos.label):
+                self.det_label[idx].set_color([0, 0, 1, 0])
+        else:
+            self.src_optodes.set_color([1, 0, 0, 0])
+            self.det_optodes.set_color([0, 0, 1, 0])
+            self.src_optodes.set_markersize(5)  # ADD THIS - Reset to original size
+            self.det_optodes.set_markersize(5)  # ADD THIS - Reset to original size
+
+            for idx, source in enumerate(self.sPos.label):
+                self.src_label[idx].set_color([1, 0, 0, 1])
+            for idx, detector in enumerate(self.dPos.label):
+                self.det_label[idx].set_color([0, 0, 1, 1])
+
+        self._ax.figure.canvas.draw()
+
+    def _toggle_measline(self):
+        if self.measline.isChecked():
+            for i_ch in range(self.channels):
+                self.meas_line[i_ch].set_color([0.8, 0.8, 0.8, 1])
+        else:
+            for i_ch in range(self.channels):
+                self.meas_line[i_ch].set_color([0.8, 0.8, 0.8, 0])
+
+        self._ax.figure.canvas.draw()
+
+    def _xscale_changed(self, i):
+        # Pass the new xscale and draw hrf again
+        self.plot_Xscale = i
+        # print(f"Changing x-scale to {self.plot_Xscale}!")
+        self.axWid = self.plot_Xscale / self.nAcross
+        self.xT = [
+            xa1
+            - self.axWid / 8
+            + (1 / 4) * self.axWid * ((self.t - self.minT) / (self.maxT - self.minT))
+            for xa1 in self.xa
+        ]
+
+        self._re_draw_hrf()
+
+    def _yscale_changed(self, i):
+        # Pass the new yscale and draw hrf again
+        self.plot_Yscale = i
+        # print(f"Changing y-scale to {self.plot_Yscale}!")
+        self.axHgt = self.plot_Yscale / self.nUp
+        for trial in range(self.trial_types):
+            self.hrfT[trial] = (
+                self.ya
+                - self.axHgt / 8
+                + (1 / 4)
+                * self.axHgt
+                * ((self.hrf_val[trial] - self.cmin) / (self.cmax - self.cmin))
+            )
+
+        self._re_draw_hrf()
+        # print("HRFs should have changed!")
+
+    def _mindist_changed(self, i):
+        # Pass the new minimum channel distance and draw hrf again
+        self.channel_min_dist = i
+
+        if self.ssfade.value() < i:
+            self.ssfade.setValue(i)
+        else:
+            self._change_hrf_vis()
+
+    def _maxdist_changed(self, i):
+        # Pass the new maximum channel distance and draw hrf again
+        self.channel_max_dist = i
+        self._change_hrf_vis()
+
+    def _ssfade_changed(self, i):
+        # Pass the fade amount and draw hrf again
+        self.ssFadeThres = i
+        self._change_hrf_vis()
+
+    def _tstat_threshold_changed(self):
+        # Pass the new t-stat threshold and update HRF visibility
+        self.tstat_thresh = self.tstat_threshold.value()
+        self._change_hrf_vis()
+    
+    def _stderr_threshold_changed(self):
+        # Pass the new stderr threshold and update HRF visibility
+        self.stderr_thresh = self.stderr_threshold.value()
+        self._change_hrf_vis()
+
+    def _draw_hrf(self):
+        print("Plotting Optodes!")
+        t0 = time.time()
+        self._ax.clear()
+
+        # Plot optode dots transparently
+        (self.src_optodes,) = self._ax.plot(
+            self.sx, self.sy, "o", markersize=5, color=[1, 0, 0, 0]
+        )
+        (self.det_optodes,) = self._ax.plot(
+            self.dx, self.dy, "o", markersize=5, color=[0, 0, 1, 0]
+        )
+
+        # Plot optode labels
+        for idx2, source in enumerate(self.sPos.label):
+            self.src_label[idx2] = self._ax.text(
+                self.sx[idx2],
+                self.sy[idx2],
+                f"{source.values}",
+                fontsize=8,
+                ha="center",
+                va="center",
+                clip_on=True,
+            )
+            self.src_label[idx2].set_color([1, 0, 0, 1])
+
+        for idx2, detector in enumerate(self.dPos.label):
+            self.det_label[idx2] = self._ax.text(
+                self.dx[idx2],
+                self.dy[idx2],
+                f"{detector.values}",
+                fontsize=8,
+                ha="center",
+                va="center",
+                clip_on=True,
+            )
+            self.det_label[idx2].set_color([0, 0, 1, 1])
+
+        print("Plotting HRFs!")
+
+        for i_con in range(self.trial_types):
+            for i_ch in range(self.channels):
+                for i_col in range(self.chromophores):
+                    (
+                        self.hrf[
+                            i_con * self.channels * self.chromophores
+                            + i_ch * self.chromophores
+                            + i_col
+                        ],
+                    ) = self._ax.plot(
+                        self.xT[i_ch],
+                        self.hrfT[i_con][i_ch][i_col],
+                        lw=self.lineWidth,
+                        zorder=2 - i_col,
+                        color=self.chrom[i_col] + [0],
+                    )
+
+        for i_ch in range(self.channels):
+            si = self.src_idx[i_ch]
+            di = self.det_idx[i_ch]
+
+            (self.meas_line[i_ch],) = self._ax.plot(
+                [self.sx[si], self.dx[di]],
+                [self.sy[si], self.dy[di]],
+                "--",
+                color=[0.8, 0.8, 0.8, 0],
+                zorder=0,
+            )
+
+        self._ax.set_aspect("equal")
+        self._ax.axis("off")
+        self._ax.figure.tight_layout()
+        self._ax.figure.canvas.draw()
+
+        t1 = time.time()
+        print(f"Everything plotted in {t1-t0:.2f} seconds!")
+
+
+# if __name__ == "__main__":
+#     app = QtWidgets.QApplication(sys.argv)
+#     main_gui = _MAIN_GUI()
+#     main_gui.show()
+#     sys.exit(app.exec())
+
+
+def run_vis(
+    blockaverage: cdt.NDTimeSeries,
+    geo2d: cdt.LabeledPoints,
+    geo3d: cdt.LabeledPoints,
+    stderr: cdt.NDTimeSeries = None,  # optional standerr input 
+):
+    """Opens the visualization GUI.
+
+    Args:
+        blockaverage: The blockaveraged HRF data.
+        geo2d: The 2d probe geometry data.
+        geo3d: The 3d probe geometry data.
+    """
+
+    app = QtWidgets.QApplication(sys.argv)
+    #main_gui = _MAIN_GUI(snirfData=blockaverage, geo2d=geo2d, geo3d=geo3d)
+    main_gui = _MAIN_GUI(snirfData=blockaverage, stderr=stderr, geo2d=geo2d, geo3d=geo3d)
+    main_gui.show()
+    sys.exit(app.exec())

--- a/workflow/scripts/homer/plot_probe_gui.py
+++ b/workflow/scripts/homer/plot_probe_gui.py
@@ -744,41 +744,22 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         t0 = time.time()
         self._ax.clear()
 
-        # Plot optode dots transparently
-        (self.src_optodes,) = self._ax.plot(
-            self.sx, self.sy, "o", markersize=5, color=[1, 0, 0, 0]
-        )
-        (self.det_optodes,) = self._ax.plot(
-            self.dx, self.dy, "o", markersize=5, color=[0, 0, 1, 0]
-        )
+        # First, plot measurement lines (lowest layer, zorder=0)
+        print("Plotting measurement lines!")
+        for i_ch in range(self.channels):
+            si = self.src_idx[i_ch]
+            di = self.det_idx[i_ch]
 
-        # Plot optode labels
-        for idx2, source in enumerate(self.sPos.label):
-            self.src_label[idx2] = self._ax.text(
-                self.sx[idx2],
-                self.sy[idx2],
-                f"{source.values}",
-                fontsize=8,
-                ha="center",
-                va="center",
-                clip_on=True,
+            (self.meas_line[i_ch],) = self._ax.plot(
+                [self.sx[si], self.dx[di]],
+                [self.sy[si], self.dy[di]],
+                "--",
+                color=[0.8, 0.8, 0.8, 0],
+                zorder=0,
             )
-            self.src_label[idx2].set_color([1, 0, 0, 1])
 
-        for idx2, detector in enumerate(self.dPos.label):
-            self.det_label[idx2] = self._ax.text(
-                self.dx[idx2],
-                self.dy[idx2],
-                f"{detector.values}",
-                fontsize=8,
-                ha="center",
-                va="center",
-                clip_on=True,
-            )
-            self.det_label[idx2].set_color([0, 0, 1, 1])
-
+        # Second, plot HRFs (middle layer, zorder=1-2)
         print("Plotting HRFs!")
-
         for i_con in range(self.trial_types):
             for i_ch in range(self.channels):
                 for i_col in range(self.chromophores):
@@ -796,17 +777,42 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                         color=self.chrom[i_col] + [0],
                     )
 
-        for i_ch in range(self.channels):
-            si = self.src_idx[i_ch]
-            di = self.det_idx[i_ch]
+        # Third, plot optode dots and labels (top layer, zorder=10)
+        # This ensures optodes are always on top and easy to click
+        print("Plotting optode markers and labels!")
+        (self.src_optodes,) = self._ax.plot(
+            self.sx, self.sy, "o", markersize=5, color=[1, 0, 0, 0], zorder=10
+        )
+        (self.det_optodes,) = self._ax.plot(
+            self.dx, self.dy, "o", markersize=5, color=[0, 0, 1, 0], zorder=10
+        )
 
-            (self.meas_line[i_ch],) = self._ax.plot(
-                [self.sx[si], self.dx[di]],
-                [self.sy[si], self.dy[di]],
-                "--",
-                color=[0.8, 0.8, 0.8, 0],
-                zorder=0,
+        # Plot optode labels (also on top layer)
+        for idx2, source in enumerate(self.sPos.label):
+            self.src_label[idx2] = self._ax.text(
+                self.sx[idx2],
+                self.sy[idx2],
+                f"{source.values}",
+                fontsize=8,
+                ha="center",
+                va="center",
+                clip_on=True,
+                zorder=10,
             )
+            self.src_label[idx2].set_color([1, 0, 0, 1])
+
+        for idx2, detector in enumerate(self.dPos.label):
+            self.det_label[idx2] = self._ax.text(
+                self.dx[idx2],
+                self.dy[idx2],
+                f"{detector.values}",
+                fontsize=8,
+                ha="center",
+                va="center",
+                clip_on=True,
+                zorder=10,
+            )
+            self.det_label[idx2].set_color([0, 0, 1, 1])
 
         self._ax.set_aspect("equal")
         self._ax.axis("off")

--- a/workflow/scripts/homer/plot_probe_gui.py
+++ b/workflow/scripts/homer/plot_probe_gui.py
@@ -152,26 +152,31 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         prune_channels_layout.addWidget(QtWidgets.QLabel("SS fade thresh"), 2, 0)
         prune_channels_layout.addWidget(self.ssfade, 2, 1)
         
-        # Add T-stat threshold (only if standard error is provided)
-        if self.stderr is not None:
-            self.tstat_threshold = QtWidgets.QDoubleSpinBox()
-            self.tstat_threshold.setValue(0)  # Default: no threshold
-            self.tstat_threshold.setRange(-100, 100)
-            self.tstat_threshold.setSingleStep(0.5)
-            self.tstat_threshold.setDecimals(2)
-            self.tstat_threshold.editingFinished.connect(self._tstat_threshold_changed)
-            prune_channels_layout.addWidget(QtWidgets.QLabel("T-stat"), 3, 0)
-            prune_channels_layout.addWidget(self.tstat_threshold, 3, 1)
-            
-            # Add std_err threshold
-            self.stderr_threshold = QtWidgets.QDoubleSpinBox()
-            self.stderr_threshold.setRange(0, 1e10)  # Set range first
-            self.stderr_threshold.setValue(1e6)  # Default: 1e6
-            self.stderr_threshold.setSingleStep(0.1)
-            self.stderr_threshold.setDecimals(8)
-            self.stderr_threshold.editingFinished.connect(self._stderr_threshold_changed)
-            prune_channels_layout.addWidget(QtWidgets.QLabel("std_err"), 4, 0)
-            prune_channels_layout.addWidget(self.stderr_threshold, 4, 1)
+        # Add T-stat threshold (always visible, disabled if no stderr data)
+        self.tstat_threshold = QtWidgets.QDoubleSpinBox()
+        self.tstat_threshold.setValue(0)  # Default: no threshold
+        self.tstat_threshold.setRange(-100, 100)
+        self.tstat_threshold.setSingleStep(0.5)
+        self.tstat_threshold.setDecimals(2)
+        self.tstat_threshold.editingFinished.connect(self._tstat_threshold_changed)
+        prune_channels_layout.addWidget(QtWidgets.QLabel("T-stat"), 3, 0)
+        prune_channels_layout.addWidget(self.tstat_threshold, 3, 1)
+        
+        # Add std_err threshold (always visible, disabled if no stderr data)
+        self.stderr_threshold = QtWidgets.QDoubleSpinBox()
+        self.stderr_threshold.setRange(0, 1e10)  # Set range first
+        self.stderr_threshold.setValue(1e6)  # Default: 1e6
+        self.stderr_threshold.setSingleStep(0.1)
+        self.stderr_threshold.setDecimals(8)
+        self.stderr_threshold.editingFinished.connect(self._stderr_threshold_changed)
+        prune_channels_layout.addWidget(QtWidgets.QLabel("std_err"), 4, 0)
+        prune_channels_layout.addWidget(self.stderr_threshold, 4, 1)
+        
+        # Initially disable both - will be enabled in _init_calc() based on data availability
+        self.tstat_threshold.setEnabled(False)
+        self.stderr_threshold.setEnabled(False)
+        self.tstat_threshold.setToolTip("T-statistic data not available")
+        self.stderr_threshold.setToolTip("Standard error data not available")
 
         ## Add Prune Channels
         control_panel_layout.addWidget(prune_channels)
@@ -332,6 +337,23 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             self.tstat = None
             self.tstat_max = None
             self.stderr_mean = None
+        
+        # Enable/disable controls based on data availability
+        if hasattr(self, 'tstat_threshold'):
+            if self.tstat_max is not None:
+                self.tstat_threshold.setEnabled(True)
+                self.tstat_threshold.setToolTip("Set threshold for t-statistic pruning")
+            else:
+                self.tstat_threshold.setEnabled(False)
+                self.tstat_threshold.setToolTip("T-statistic data not available")
+        
+        if hasattr(self, 'stderr_threshold'):
+            if self.stderr_mean is not None:
+                self.stderr_threshold.setEnabled(True)
+                self.stderr_threshold.setToolTip("Set threshold for standard error pruning")
+            else:
+                self.stderr_threshold.setEnabled(False)
+                self.stderr_threshold.setToolTip("Standard error data not available")
 
         self.conditions.clear()
         self.opt2circ.setChecked(False)

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -6494,12 +6494,23 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         # Single file mode - check the specific file
         file_path = file_paths_to_check[0]
         
-        # Check if file is in current scope (user's config)
+        # First check if file exists on disk
+        import os
+        file_exists = os.path.exists(file_path)
+        print(f"DEBUG: File exists on disk? {file_exists}")
+        
+        # If file exists on disk, it's up-to-date (black)
+        # We don't need Snakemake to tell us a file that exists is complete
+        if file_exists:
+            print(f"DEBUG: File exists, returning black")
+            return 'black'
+        
+        # File doesn't exist yet - check if it's in the pipeline scope
         in_current_scope = file_path in self.current_scope_files
         print(f"DEBUG: In current scope? {in_current_scope}")
         
         if not in_current_scope:
-            # Not in current config → gray (don't care about status)
+            # Not in current config and doesn't exist → gray (out of scope)
             print(f"DEBUG: Not in current scope, returning gray")
             return 'gray'
         

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -1292,6 +1292,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         # Axis zoom preservation
         self.preserved_xlim = None  # Store x-axis limits
         self.preserved_ylim = None  # Store y-axis limits
+        
+        # GUI state restoration flag
+        self._restoring_state = False  # Set to True while restoring saved state
 
         self._UI_SETUP()
         
@@ -1301,19 +1304,28 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         # Restore pipeline state and update colors
         self._restore_pipeline_state()
         
-        # Get the initial recording
-        if self.subjects:
+        # Check if we have saved GUI state to restore
+        has_saved_state = self._check_for_saved_gui_state()
+        
+        # Get the initial recording (only if no saved state to restore)
+        if not has_saved_state and self.subjects:
             initial_subject = self.subjects[0]
             if initial_subject in self.file_map and self.subject_to_runs_map.get(initial_subject):
                  initial_run = self.subject_to_runs_map[initial_subject][0]
                  self._update_recording_data(initial_subject, initial_run, subject_changed=True)
 
-        if self.snirfRec is None:
+        if self.snirfRec is None and not has_saved_state:
              print("Warning: Could not load an initial recording.")
         
+        # Load saved GUI state (subject, run, selections, etc.)
+        if has_saved_state:
+            self._load_gui_state()
     
     def closeEvent(self, event):
         """Clean up resources when GUI is closed"""
+        # Save current GUI state before closing
+        self._save_gui_state()
+        
         # Stop monitoring
         if self.pipeline_monitor_timer:
             self.pipeline_monitor_timer.stop()
@@ -2595,14 +2607,32 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         """Save homer.config file with Snakefile, config paths, and pipeline status"""
         try:
             homer_config_path = os.path.join(derivatives_dir, 'homer.config')
-            homer_config = {
-                'snakefile_path': snakefile_path,
-                'config_path': config_path
-            }
+            
+            # Load existing config to preserve other sections (like gui_state)
+            homer_config = {}
+            if os.path.exists(homer_config_path):
+                try:
+                    with open(homer_config_path, 'r') as f:
+                        homer_config = yaml.safe_load(f) or {}
+                except yaml.constructor.ConstructorError:
+                    try:
+                        with open(homer_config_path, 'r') as f:
+                            homer_config = yaml.unsafe_load(f) or {}
+                    except:
+                        homer_config = {}
+            
+            # Update snakemake paths
+            homer_config['snakefile_path'] = snakefile_path
+            homer_config['config_path'] = config_path
+            
             if pipeline_status:
                 homer_config['pipeline_status'] = pipeline_status
+            
+            # Clean config to remove numpy objects before saving
+            homer_config_clean = self._clean_config_for_yaml(homer_config)
+            
             with open(homer_config_path, 'w') as f:
-                yaml.dump(homer_config, f, default_flow_style=False)
+                yaml.dump(homer_config_clean, f, default_flow_style=False, sort_keys=False)
             print(f"Saved homer.config to {homer_config_path}")
         except Exception as e:
             print(f"Warning: Could not save homer.config: {str(e)}")
@@ -2624,8 +2654,23 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             
             print(f"Found homer.config at {homer_config_path}")
             
-            with open(homer_config_path, 'r') as f:
-                homer_config = yaml.safe_load(f)
+            # Try safe_load first, fall back to unsafe if needed
+            homer_config = None
+            try:
+                with open(homer_config_path, 'r') as f:
+                    homer_config = yaml.safe_load(f)
+            except yaml.constructor.ConstructorError:
+                # File contains unsafe YAML tags (numpy objects, etc.)
+                print("Warning: homer.config contains unsafe YAML tags, using unsafe_load")
+                try:
+                    with open(homer_config_path, 'r') as f:
+                        homer_config = yaml.unsafe_load(f)
+                except Exception as e:
+                    print(f"Warning: Could not load homer.config even with unsafe_load: {e}")
+                    return
+            
+            if not homer_config:
+                return
             
             snakefile_path = homer_config.get('snakefile_path')
             config_path = homer_config.get('config_path')
@@ -2642,6 +2687,341 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                         print(f"  Config not found: {config_path}")
         except Exception as e:
             print(f"Warning: Could not auto-load homer.config: {str(e)}")
+    
+    def _save_gui_state(self):
+        """Save current GUI state (subject, run, selections) to homer.config"""
+        try:
+            # Don't save if we're in the middle of restoring state
+            if hasattr(self, '_restoring_state') and self._restoring_state:
+                return
+            
+            if not self.path_to_data or not os.path.exists(self.path_to_data):
+                return
+            
+            homer_config_path = os.path.join(self.path_to_data, 'homer.config')
+            
+            # Load existing config or create new one
+            # Try safe_load first, fall back to unsafe if needed
+            homer_config = {}
+            if os.path.exists(homer_config_path):
+                try:
+                    with open(homer_config_path, 'r') as f:
+                        homer_config = yaml.safe_load(f) or {}
+                except yaml.constructor.ConstructorError:
+                    # File contains unsafe YAML tags (e.g., numpy objects)
+                    # Load with unsafe_load but only extract safe parts
+                    try:
+                        with open(homer_config_path, 'r') as f:
+                            homer_config = yaml.unsafe_load(f) or {}
+                    except:
+                        homer_config = {}
+            
+            # Collect GUI state
+            gui_state = {}
+            
+            # Subject and run
+            if hasattr(self, 'subj') and self.subj.currentText():
+                gui_state['subject'] = str(self.subj.currentText())
+            if hasattr(self, 'run') and self.run.currentText():
+                gui_state['run'] = str(self.run.currentText())
+            
+            # Timeseries selection
+            if hasattr(self, 'ts') and self.ts.currentItem():
+                gui_state['timeseries'] = str(self.ts.currentItem().text())
+            
+            # Wavelength/chromo selection
+            if hasattr(self, 'wv'):
+                gui_state['wavelength_index'] = int(self.wv.currentRow())
+            
+            # Selected channels - convert to native Python ints
+            if hasattr(self, 'selected_channels'):
+                gui_state['selected_channels'] = [int(ch) for ch in self.selected_channels]
+            
+            # Preserve axis zoom checkbox state
+            if hasattr(self, 'preserve_axis_zoom'):
+                gui_state['preserve_axis_zoom'] = bool(self.preserve_axis_zoom.isChecked())
+            
+            # View optodes as circles checkbox state
+            if hasattr(self, 'opt2circ'):
+                gui_state['opt2circ'] = bool(self.opt2circ.isChecked())
+            
+            # Auxiliary data selection
+            if hasattr(self, 'aux') and self.aux.currentText():
+                gui_state['aux'] = str(self.aux.currentText())
+            
+            # Selected stimulus types (for both regular and HRF view)
+            if hasattr(self, 'selected_stim_types'):
+                gui_state['selected_stim_types'] = [str(s) for s in self.selected_stim_types]
+            
+            # HRF view state
+            if hasattr(self, 'hrf_view'):
+                gui_state['hrf_view'] = bool(self.hrf_view.isChecked())
+                if self.hrf_view.isChecked():
+                    if hasattr(self, 'hrf_hbo'):
+                        gui_state['hrf_hbo'] = bool(self.hrf_hbo.isChecked())
+                    if hasattr(self, 'hrf_hbr'):
+                        gui_state['hrf_hbr'] = bool(self.hrf_hbr.isChecked())
+                    if hasattr(self, 'hrf_group_avg'):
+                        gui_state['hrf_group_avg'] = bool(self.hrf_group_avg.isChecked())
+            
+            # Update homer.config with gui_state
+            homer_config['gui_state'] = gui_state
+            
+            # Clean homer_config to remove any numpy objects before saving
+            homer_config_clean = self._clean_config_for_yaml(homer_config)
+            
+            # Write back to file
+            with open(homer_config_path, 'w') as f:
+                yaml.dump(homer_config_clean, f, default_flow_style=False, sort_keys=False)
+            
+            print(f"Saved GUI state to {homer_config_path}")
+            
+        except Exception as e:
+            print(f"Warning: Could not save GUI state: {str(e)}")
+            import traceback
+            traceback.print_exc()
+    
+    def _clean_config_for_yaml(self, obj):
+        """Recursively clean config object to remove numpy types and make it YAML-safe"""
+        if isinstance(obj, dict):
+            return {str(k): self._clean_config_for_yaml(v) for k, v in obj.items()}
+        elif isinstance(obj, (list, tuple)):
+            return [self._clean_config_for_yaml(item) for item in obj]
+        elif isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        elif isinstance(obj, (str, int, float, bool)) or obj is None:
+            return obj
+        else:
+            # For other types, try to convert to string
+            try:
+                return str(obj)
+            except:
+                return None
+    
+    def _check_for_saved_gui_state(self):
+        """Check if there's a saved GUI state in homer.config"""
+        try:
+            if not self.path_to_data or not os.path.exists(self.path_to_data):
+                return False
+            
+            homer_config_path = os.path.join(self.path_to_data, 'homer.config')
+            
+            if not os.path.exists(homer_config_path):
+                return False
+            
+            # Try to load and check for gui_state section
+            try:
+                with open(homer_config_path, 'r') as f:
+                    homer_config = yaml.safe_load(f)
+            except yaml.constructor.ConstructorError:
+                try:
+                    with open(homer_config_path, 'r') as f:
+                        homer_config = yaml.unsafe_load(f)
+                except:
+                    return False
+            
+            return homer_config is not None and 'gui_state' in homer_config
+            
+        except Exception:
+            return False
+    
+    def _load_gui_state(self):
+        """Load and restore GUI state from homer.config"""
+        try:
+            if not self.path_to_data or not os.path.exists(self.path_to_data):
+                return
+            
+            homer_config_path = os.path.join(self.path_to_data, 'homer.config')
+            
+            if not os.path.exists(homer_config_path):
+                return
+            
+            # Try safe_load first, fall back to unsafe if needed
+            homer_config = None
+            try:
+                with open(homer_config_path, 'r') as f:
+                    homer_config = yaml.safe_load(f)
+            except yaml.constructor.ConstructorError:
+                # File contains unsafe YAML tags - try unsafe_load
+                try:
+                    with open(homer_config_path, 'r') as f:
+                        homer_config = yaml.unsafe_load(f)
+                except Exception as e:
+                    print(f"Warning: Could not load homer.config even with unsafe_load: {e}")
+                    return
+            
+            if not homer_config or 'gui_state' not in homer_config:
+                return
+            
+            gui_state = homer_config['gui_state']
+            print(f"Restoring GUI state from homer.config: {list(gui_state.keys())}")
+            
+            # Set a flag to prevent saving during restoration
+            self._restoring_state = True
+            
+            try:
+                # Restore subject
+                if 'subject' in gui_state and hasattr(self, 'subj'):
+                    subject = gui_state['subject']
+                    index = self.subj.findText(subject)
+                    if index >= 0:
+                        self.subj.blockSignals(True)
+                        self.subj.setCurrentIndex(index)
+                        self.subj.blockSignals(False)
+                        print(f"  Restored subject: {subject}")
+                
+                # Restore run
+                if 'run' in gui_state and hasattr(self, 'run'):
+                    run = gui_state['run']
+                    # Update run list for the selected subject first
+                    if hasattr(self, 'subj'):
+                        subject_key = self.subj.currentText()
+                        if subject_key in self.subject_to_runs_map:
+                            self.run.blockSignals(True)
+                            self.run.clear()
+                            self.run.addItems(self.subject_to_runs_map[subject_key])
+                            self.run.blockSignals(False)
+                    
+                    # Now set the run
+                    index = self.run.findText(run)
+                    if index >= 0:
+                        self.run.blockSignals(True)
+                        self.run.setCurrentIndex(index)
+                        self.run.blockSignals(False)
+                        print(f"  Restored run: {run}")
+                
+                # Load the data for subject/run before restoring other selections
+                if 'subject' in gui_state and 'run' in gui_state:
+                    self._update_recording_data(gui_state['subject'], gui_state['run'], subject_changed=True)
+                
+                # Restore timeseries selection
+                if 'timeseries' in gui_state and hasattr(self, 'ts') and hasattr(self, 'snirfRec'):
+                    ts_name = gui_state['timeseries']
+                    for i in range(self.ts.count()):
+                        if self.ts.item(i).text() == ts_name:
+                            self.ts.blockSignals(True)
+                            self.ts.setCurrentRow(i)
+                            self.ts.blockSignals(False)
+                            # Manually trigger the timeseries change without saving
+                            if ts_name != 'amp' and self.processed_rec and hasattr(self.processed_rec, 'timeseries') and ts_name in self.processed_rec.timeseries:
+                                self.snirfData = self.processed_rec.timeseries[ts_name]
+                            else:
+                                self.snirfData = self.snirfRec.timeseries.get(ts_name)
+                            self.ts_sel = ts_name
+                            print(f"  Restored timeseries: {ts_name}")
+                            break
+                
+                # Update wavelength/concentration dropdown based on timeseries
+                if hasattr(self, 'snirfData') and self.snirfData is not None:
+                    if "wavelength" in self.snirfData.dims:
+                        self.wv_label.setText("Wavelength:")
+                        self.wv.clear()
+                        for i_w, wvl in enumerate(self.snirfData.wavelength.values):
+                            self.wv.insertItem(i_w, str(wvl))
+                    elif "chromo" in self.snirfData.dims:
+                        self.wv_label.setText("Concentration:")
+                        self.wv.clear()
+                        for i_w, wvl in enumerate(self.snirfData.chromo.values):
+                            self.wv.insertItem(i_w, f"[{str(wvl)}]")
+                
+                # Restore wavelength/chromo index
+                if 'wavelength_index' in gui_state and hasattr(self, 'wv'):
+                    wv_index = gui_state['wavelength_index']
+                    if 0 <= wv_index < self.wv.count():
+                        self.wv.blockSignals(True)
+                        self.wv.setCurrentRow(wv_index)
+                        self.wv.blockSignals(False)
+                        print(f"  Restored wavelength index: {wv_index}")
+                
+                # Restore selected channels
+                if 'selected_channels' in gui_state and hasattr(self, 'snirfData') and self.snirfData is not None:
+                    saved_channels = gui_state['selected_channels']
+                    # Validate channels are within range
+                    max_channel = len(self.snirfData.channel.values) - 1
+                    valid_channels = [ch for ch in saved_channels if 0 <= ch <= max_channel]
+                    self.selected_channels = valid_channels
+                    print(f"  Restored {len(valid_channels)} selected channels")
+                
+                # Restore preserve axis zoom state
+                if 'preserve_axis_zoom' in gui_state and hasattr(self, 'preserve_axis_zoom'):
+                    self.preserve_axis_zoom.blockSignals(True)
+                    self.preserve_axis_zoom.setChecked(gui_state['preserve_axis_zoom'])
+                    self.preserve_axis_zoom.blockSignals(False)
+                    print(f"  Restored preserve_axis_zoom: {gui_state['preserve_axis_zoom']}")
+                
+                # Restore view optodes as circles state
+                if 'opt2circ' in gui_state and hasattr(self, 'opt2circ'):
+                    self.opt2circ.blockSignals(True)
+                    self.opt2circ.setChecked(gui_state['opt2circ'])
+                    self.opt2circ.blockSignals(False)
+                    # Manually trigger the toggle to update visibility
+                    self._toggle_circles()
+                    print(f"  Restored opt2circ: {gui_state['opt2circ']}")
+                
+                # Restore auxiliary selection
+                if 'aux' in gui_state and hasattr(self, 'aux'):
+                    aux_name = gui_state['aux']
+                    index = self.aux.findText(aux_name)
+                    if index >= 0:
+                        self.aux.blockSignals(True)
+                        self.aux.setCurrentIndex(index)
+                        self.aux.blockSignals(False)
+                        # Manually set aux selection
+                        if aux_name != "None" and aux_name != "dark signal":
+                            self.aux_sel = self.snirfRec.aux_ts[aux_name]
+                            self.aux_type = aux_name
+                        else:
+                            self.aux_sel = []
+                            self.aux_type = None
+                        print(f"  Restored aux: {aux_name}")
+                
+                # Restore selected stimulus types (for both regular and HRF view)
+                if 'selected_stim_types' in gui_state:
+                    if hasattr(self, 'available_stim_types'):
+                        # Only restore stimuli that are available in current dataset
+                        saved_stims = set(gui_state['selected_stim_types'])
+                        valid_stims = saved_stims.intersection(set(self.available_stim_types))
+                        self.selected_stim_types = valid_stims
+                        self._update_stim_button_text()
+                        print(f"  Restored {len(valid_stims)} selected stimuli")
+                    else:
+                        # Store for later if available_stim_types not yet set
+                        self.selected_stim_types = set(gui_state['selected_stim_types'])
+                        print(f"  Stored {len(self.selected_stim_types)} selected stimuli")
+                
+                # Restore HRF view state
+                if 'hrf_view' in gui_state and hasattr(self, 'hrf_view'):
+                    self.hrf_view.setChecked(gui_state['hrf_view'])
+                    
+                    if gui_state['hrf_view']:
+                        if 'hrf_hbo' in gui_state and hasattr(self, 'hrf_hbo'):
+                            self.hrf_hbo.setChecked(gui_state['hrf_hbo'])
+                        if 'hrf_hbr' in gui_state and hasattr(self, 'hrf_hbr'):
+                            self.hrf_hbr.setChecked(gui_state['hrf_hbr'])
+                        if 'hrf_group_avg' in gui_state and hasattr(self, 'hrf_group_avg'):
+                            self.hrf_group_avg.setChecked(gui_state['hrf_group_avg'])
+                        print(f"  Restored HRF view state")
+                
+                # Redraw with restored state
+                if hasattr(self, 'snirfData') and self.snirfData is not None:
+                    self._draw_timeseries()
+                    print("GUI state restored successfully")
+                else:
+                    print("GUI state partially restored (no data to draw)")
+                
+            finally:
+                # Clear the restoration flag
+                self._restoring_state = False
+            
+        except Exception as e:
+            print(f"Warning: Could not load GUI state: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            self._restoring_state = False
     
     def _load_snakemake_config(self, snakefile_path, config_path):
         """Load Snakemake config and update menu dynamically"""
@@ -3334,6 +3714,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             self.selected_channels = [channel_idx]
         
         self._draw_timeseries()
+        
+        # Save GUI state after channel selection
+        self._save_gui_state()
 
     def _optode_scatter_picked(self, event):
         """Handle clicking on optodes - toggles channels from optode in selection"""
@@ -3400,6 +3783,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self.selected = []
         
         self._draw_timeseries()
+        
+        # Save GUI state after optode selection
+        self._save_gui_state()
 
     def _toggle_circles(self):
         if self.opt2circ.isChecked():
@@ -3431,6 +3817,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             self.preserved_xlim = None
             self.preserved_ylim = None
             print("Preserve zoom disabled. Cleared saved limits.")
+        
+        # Save GUI state after preserve zoom setting change
+        self._save_gui_state()
     
     def _on_xlims_change(self, event_ax):
         """Callback when axis limits change (e.g., after zooming)"""
@@ -3472,6 +3861,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self._update_combobox_selection_colors()
         
         self._draw_timeseries()
+        
+        # Save GUI state after HRF view toggle
+        self._save_gui_state()
     
     def _hrf_group_avg_changed(self):
         """Handle changes to HRF group average checkbox"""
@@ -3489,11 +3881,15 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         if self.hrf_view.isChecked():
             print("Calling _draw_timeseries from _hrf_group_avg_changed")
             self._draw_timeseries()
+            # Save GUI state after HRF group average change
+            self._save_gui_state()
     
     def _hrf_chromo_changed(self):
         """Handle changes to HRF chromophore selection"""
         if self.hrf_view.isChecked():
             self._draw_timeseries()
+            # Save GUI state after HRF chromophore change
+            self._save_gui_state()
     
     def _color_file_type_changed(self):
         """Handle changes to color file type filter - update all file colors"""
@@ -4292,6 +4688,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             
             self._update_stim_button_text()
             self._draw_timeseries()
+            
+            # Save GUI state after stimuli selection change
+            self._save_gui_state()
 
     def _select_all_stims(self, select_all):
         """Select or deselect all stimulus checkboxes"""
@@ -4347,6 +4746,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         
         # Update current selection colors
         self._update_combobox_selection_colors()
+        
+        # Save GUI state after run change
+        self._save_gui_state()
 
     def _update_run_box(self):
         """(DEPRECATED) - This logic is now handled in _subj_changed."""
@@ -4479,6 +4881,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
 
     def _wv_changed(self):
         self._draw_timeseries()
+        
+        # Save GUI state after wavelength change
+        self._save_gui_state()
 
     def _ts_changed(self, s):
         # Extract data
@@ -4514,6 +4919,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             self.wv.setCurrentRow(0)
 
         self._draw_timeseries()
+        
+        # Save GUI state after timeseries change
+        self._save_gui_state()
 
     def _update_channel_highlights(self):
         """Update the channel line highlighting on the probe display"""
@@ -5139,6 +5547,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             self.aux_type = s
 
         self._draw_timeseries()
+        
+        # Save GUI state after auxiliary selection change
+        self._save_gui_state()
 
     # ============== Pipeline Monitoring Methods ==============
     
@@ -5448,10 +5859,22 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             homer_config_path = os.path.join(derivatives_dir, 'homer.config')
             
             if os.path.exists(homer_config_path):
-                with open(homer_config_path, 'r') as f:
-                    homer_config = yaml.safe_load(f) or {}
+                # Try safe_load first, fall back to unsafe if needed
+                homer_config = None
+                try:
+                    with open(homer_config_path, 'r') as f:
+                        homer_config = yaml.safe_load(f) or {}
+                except yaml.constructor.ConstructorError:
+                    print("Warning: homer.config contains unsafe YAML tags, using unsafe_load for pipeline state")
+                    try:
+                        with open(homer_config_path, 'r') as f:
+                            homer_config = yaml.unsafe_load(f) or {}
+                    except Exception as e:
+                        print(f"Warning: Could not load homer.config even with unsafe_load: {e}")
+                        return
                 
                 self.pipeline_status = homer_config.get('pipeline_status', {})
+                print(f"DEBUG: Restored pipeline_status: {self.pipeline_status}")
                 print(f"DEBUG: Restored pipeline_status: {self.pipeline_status}")
                 
                 # Restore expected and completed outputs

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -35,6 +35,42 @@ import cedalion.dataclasses as cdc
 warnings.simplefilter("ignore")
 
 
+def _resolve_conda_command():
+    """Return an executable Conda command, including .bat on Windows."""
+    candidates = ['conda.exe', 'conda.bat', 'conda']
+    for candidate in candidates:
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+
+    user_home = os.path.expanduser('~')
+    if sys.platform == 'win32':
+        candidates = [
+            os.path.join(user_home, 'AppData', 'Local', 'miniconda3', 'condabin', 'conda.bat'),
+            os.path.join(user_home, 'AppData', 'Local', 'anaconda3', 'condabin', 'conda.bat'),
+            os.path.join(user_home, 'miniconda3', 'condabin', 'conda.bat'),
+            os.path.join(user_home, 'anaconda3', 'condabin', 'conda.bat'),
+            r'C:\ProgramData\miniconda3\condabin\conda.bat',
+            r'C:\ProgramData\anaconda3\condabin\conda.bat',
+        ]
+    else:
+        candidates = [
+            os.path.join(user_home, 'miniconda3', 'bin', 'conda'),
+            os.path.join(user_home, 'anaconda3', 'bin', 'conda'),
+            '/opt/miniconda3/bin/conda',
+            '/opt/anaconda3/bin/conda',
+        ]
+
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+
+    raise FileNotFoundError(
+        "Could not locate the Conda executable. Start HomerPy from an "
+        "Anaconda/Miniconda prompt or add Conda's condabin directory to PATH."
+    )
+
+
 class ConfigEditorDialog(QtWidgets.QDialog):
     """Dialog for editing YAML configuration blocks"""
     
@@ -569,63 +605,12 @@ class SnakemakeRunDialog(QtWidgets.QDialog):
         environments = []
         error_msg = None
         
-        # Try to find conda executable
-        conda_cmd = None
-        
-        # First, try standard PATH lookup
-        for cmd in ['conda', 'conda.bat', 'conda.exe']:
-            if shutil.which(cmd):
-                conda_cmd = cmd
-                print(f"DEBUG: Found conda in PATH: {conda_cmd}")
-                break
-        
-        # If not in PATH, try common installation locations
-        if not conda_cmd:
-            print("DEBUG: conda not in PATH, checking common installation locations...")
-            possible_paths = []
-            
-            # Windows common locations
-            if sys.platform == 'win32':
-                user_home = os.path.expanduser('~')
-                possible_paths = [
-                    os.path.join(user_home, 'anaconda3', 'Scripts', 'conda.exe'),
-                    os.path.join(user_home, 'Anaconda3', 'Scripts', 'conda.exe'),
-                    os.path.join(user_home, 'miniconda3', 'Scripts', 'conda.exe'),
-                    os.path.join(user_home, 'Miniconda3', 'Scripts', 'conda.exe'),
-                    r'C:\ProgramData\anaconda3\Scripts\conda.exe',
-                    r'C:\ProgramData\Anaconda3\Scripts\conda.exe',
-                    r'C:\ProgramData\miniconda3\Scripts\conda.exe',
-                    r'C:\tools\anaconda3\Scripts\conda.exe',
-                    r'C:\tools\miniconda3\Scripts\conda.exe',
-                ]
-            else:
-                # Unix/Mac common locations
-                user_home = os.path.expanduser('~')
-                possible_paths = [
-                    os.path.join(user_home, 'anaconda3', 'bin', 'conda'),
-                    os.path.join(user_home, 'miniconda3', 'bin', 'conda'),
-                    os.path.join(user_home, 'opt', 'anaconda3', 'bin', 'conda'),
-                    os.path.join(user_home, 'opt', 'miniconda3', 'bin', 'conda'),
-                    '/opt/anaconda3/bin/conda',
-                    '/opt/miniconda3/bin/conda',
-                    '/usr/local/anaconda3/bin/conda',
-                    '/usr/local/miniconda3/bin/conda',
-                ]
-            
-            for path in possible_paths:
-                if os.path.isfile(path):
-                    conda_cmd = path
-                    print(f"DEBUG: Found conda at: {conda_cmd}")
-                    break
-        
-        if not conda_cmd:
-            error_msg = "conda command not found in PATH or common installation locations."
+        try:
+            conda_cmd = _resolve_conda_command()
+            print(f"DEBUG: Resolved conda command: {conda_cmd}")
+        except FileNotFoundError as e:
+            error_msg = str(e)
             print(f"ERROR: {error_msg}")
-            print("DEBUG: Checked for: conda, conda.bat, conda.exe in PATH")
-            print(f"DEBUG: Checked {len(possible_paths) if 'possible_paths' in locals() else 0} common installation paths")
-            print(f"DEBUG: System PATH: {os.environ.get('PATH', 'N/A')[:200]}...")
-            print("HINT: If conda works in terminal, try running the GUI from an Anaconda/Miniconda prompt")
-            # Return fallback defaults
             return ["cedalion_snakemake", "cedalion_snakemake_dev"]
         
         try:
@@ -635,7 +620,7 @@ class SnakemakeRunDialog(QtWidgets.QDialog):
                 capture_output=True,
                 text=True,
                 timeout=10,
-                shell=(sys.platform == 'win32')  # Use shell on Windows for .bat files
+                shell=False
             )
             
             print(f"DEBUG: conda env list return code: {result.returncode}")
@@ -872,7 +857,7 @@ class SummaryWorker(QtCore.QThread):
         try:
             # Build command with conda activation if environment is set
             if self.conda_env:
-                cmd = ['conda', 'run', '-n', self.conda_env, '--no-capture-output',
+                cmd = [_resolve_conda_command(), 'run', '-n', self.conda_env, '--no-capture-output',
                        'snakemake', '-s', self.snakefile_path,
                        '--configfile', self.config_path, '--nolock', '--summary', self.target_rule]
             else:
@@ -2427,6 +2412,12 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             
             if config_path:
                 cmd.extend(['--configfile', config_path])
+
+            # Long absolute output paths can exceed Windows' per-filename limit
+            # when Snakemake Base64-encodes them for provenance metadata.
+            # Outputs and normal dependency checks are unaffected.
+            if sys.platform == 'win32':
+                cmd.append('--drop-metadata')
             
             if dry_run:
                 cmd.append('-n')
@@ -2460,8 +2451,10 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 try:
                     # First, unlock the directory in case of stale locks
                     print("Unlocking workflow directory...")
-                    unlock_cmd = ['conda', 'run', '-n', conda_env, '--no-capture-output',
+                    conda_cmd = _resolve_conda_command()
+                    unlock_cmd = [conda_cmd, 'run', '-n', conda_env, '--no-capture-output',
                                   'snakemake', '-s', snakefile_path, '--configfile', config_path, '--unlock']
+                    print(f"DEBUG: Unlock command: {subprocess.list2cmdline(unlock_cmd)}")
                     unlock_result = subprocess.run(unlock_cmd, capture_output=True, text=True, timeout=30)
                     if unlock_result.returncode == 0:
                         print("Workflow directory unlocked successfully")
@@ -2492,7 +2485,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                         print(f"Files needing processing: {len(self.expected_pipeline_outputs)}")
                     else:
                         print("WARNING: No workflow files detected from summary")
-                        QtWidgets.QMessageBox.warning(
+                        response = QtWidgets.QMessageBox.warning(
                             self,
                             "Summary Warning",
                             "Summary did not detect any workflow files.\n\n"
@@ -2502,7 +2495,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                             "Do you want to continue anyway?",
                             QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
                         )
-                        if QtWidgets.QMessageBox.No:
+                        if response == QtWidgets.QMessageBox.No:
                             return
                         self.current_scope_files = {}
                         self.file_status_map = {}
@@ -2536,19 +2529,19 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                     
                     # Run in a new console window on Windows
                     if sys.platform == 'win32':
-                        # Launch in new terminal and capture the process
-                        # We need to start cmd with the command, and get the child snakemake process
-                        cmd_str = ' '.join(f'"{part}"' if ' ' in part else part for part in cmd)
-                        
-                        # TEMPORARY: Keep terminal open for ALL runs to debug issues
-                        terminal_flag = '/k'  # Keep terminal open
-                        # if dry_run or show_summary:
-                        #     terminal_flag = '/k'  # Keep terminal open
-                        # else:
-                        #     terminal_flag = '/c'  # Close terminal when done
-                        
-                        full_cmd = f'start "Snakemake Pipeline" cmd {terminal_flag} "conda activate {conda_env} && {cmd_str}"'
-                        subprocess.Popen(full_cmd, shell=True)
+                        # Use the resolved Conda executable directly. This avoids
+                        # relying on a shell-specific "conda activate" alias.
+                        launch_cmd = [
+                            conda_cmd, 'run', '-n', conda_env, '--no-capture-output',
+                            *cmd,
+                        ]
+                        print(f"DEBUG: Launch command: {subprocess.list2cmdline(launch_cmd)}")
+                        console_command = subprocess.list2cmdline(launch_cmd)
+                        subprocess.Popen(
+                            [os.environ.get('COMSPEC', r'C:\Windows\System32\cmd.exe'),
+                             '/k', console_command],
+                            creationflags=subprocess.CREATE_NEW_CONSOLE,
+                        )
                         
                         # Only monitor actual pipeline runs, not dry runs or summaries
                         if not dry_run and not show_summary:
@@ -5794,7 +5787,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             # Build command with conda activation if environment is set
             if self.conda_env:
                 # Use 'conda run' for proper environment activation
-                cmd = ['conda', 'run', '-n', self.conda_env, '--no-capture-output', 
+                cmd = [_resolve_conda_command(), 'run', '-n', self.conda_env, '--no-capture-output',
                        'snakemake', '-s', snakefile_path, '--configfile', config_path, '--nolock', '--summary', target_rule]
             else:
                 cmd = ['snakemake', '-s', snakefile_path, '--configfile', config_path, '--nolock', '--summary', target_rule]

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -3650,6 +3650,29 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
 
         self._optode_ax.clear()
 
+        # First, draw channel lines (bottom layer, zorder=1)
+        # Drawing them first ensures they're underneath everything else
+        self.channel_lines = []
+        for i_ch in range(self.no_channels):
+            si = self.src_idx[i_ch]
+            di = self.det_idx[i_ch]
+
+            line, = self._optode_ax.plot(
+                [self.sx[si], self.dx[di]],
+                [self.sy[si], self.dy[di]],
+                "-",
+                color=[0.8, 0.8, 0.8],
+                zorder=1,
+                picker=True,  # Enable picking but with very precise detection
+                pickradius=1,  # Very small radius for precise line selection
+                linewidth=2  # Make lines slightly thicker for easier clicking
+            )
+            # Store the line with its channel index
+            line.channel_index = i_ch
+            self.channel_lines.append(line)
+
+        # Second, draw the invisible picker scatter (middle layer, zorder=10)
+        # This is drawn on top of lines to prioritize optode clicks
         self.picker = self._optode_ax.scatter(
             self.sdx,
             self.sdy,
@@ -3658,6 +3681,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             picker=6,   # Reduced from 8 for more precise clicking
         )
 
+        # Third, draw visible optode circles (top layer, zorder=15)
         self.optodes = self._optode_ax.scatter(
             self.sdx,
             self.sdy,
@@ -3666,6 +3690,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             visible=False,
         )
 
+        # Finally, draw optode labels (highest layer, zorder=20)
         for idx, source in enumerate(self.sPos.label):
             self.src_label[idx] = self._optode_ax.text(
                 self.sx[idx],
@@ -3691,26 +3716,6 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 zorder=20,  # Highest z-order so text is always visible
                 clip_on=True,
             )
-
-        # Store channel lines for picking
-        self.channel_lines = []
-        for i_ch in range(self.no_channels):
-            si = self.src_idx[i_ch]
-            di = self.det_idx[i_ch]
-
-            line, = self._optode_ax.plot(
-                [self.sx[si], self.dx[di]],
-                [self.sy[si], self.dy[di]],
-                "-",
-                color=[0.8, 0.8, 0.8],
-                zorder=1,
-                picker=True,  # Enable picking but with very precise detection
-                pickradius=1,  # Very small radius for precise line selection
-                linewidth=2  # Make lines slightly thicker for easier clicking
-            )
-            # Store the line with its channel index
-            line.channel_index = i_ch
-            self.channel_lines.append(line)
 
         self.optodes_drawn = True
 

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -1,0 +1,6089 @@
+"""Interactive GUI to plot fNIRS probe and channel time courses.
+
+Initial Contributors:
+    - Sung Ahn | ahnsm@bu.edu | 2024
+"""
+
+import sys
+import time
+import warnings
+import pickle
+import gzip
+import os
+import shutil
+import psutil
+import yaml
+import re
+import subprocess
+import copy
+from datetime import datetime, timedelta
+from collections import OrderedDict
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from matplotlib.backends.backend_qtagg import FigureCanvas
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.backends.qt_compat import QtCore, QtWidgets, QtGui
+from PySide6.QtGui import QAction
+from matplotlib.figure import Figure
+
+import cedalion
+import cedalion.dataclasses as cdc
+
+warnings.simplefilter("ignore")
+
+
+class ConfigEditorDialog(QtWidgets.QDialog):
+    """Dialog for editing YAML configuration blocks"""
+    
+    def __init__(self, config_data, block_name, readonly_keys=None, field_tooltips=None, parent=None):
+        super().__init__(parent)
+        self.config_data = config_data
+        self.block_name = block_name
+        self.readonly_keys = readonly_keys or []
+        self.field_tooltips = field_tooltips or {}  # Map of field_key -> tooltip text
+        self.field_widgets = {}
+        
+        self.setWindowTitle(f"Edit {block_name.replace('_', ' ').title()} Configuration")
+        self.setMinimumWidth(600)
+        self.setMinimumHeight(400)
+        
+        self.init_ui()
+    
+    def init_ui(self):
+        layout = QtWidgets.QVBoxLayout()
+        
+        # Add scroll area for the form
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll_widget = QtWidgets.QWidget()
+        self.form_layout = QtWidgets.QFormLayout()
+        scroll_widget.setLayout(self.form_layout)
+        scroll.setWidget(scroll_widget)
+        
+        # Build form from config data
+        self._build_form(self.config_data, "")
+        
+        layout.addWidget(scroll)
+        
+        # Add buttons
+        button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+        
+        self.setLayout(layout)
+    
+    def _build_form(self, data, prefix=""):
+        """Recursively build form from nested dict"""
+        if not isinstance(data, dict):
+            return
+            
+        for key, value in data.items():
+            full_key = f"{prefix}.{key}" if prefix else key
+            
+            if isinstance(value, dict):
+                # Add a section label for nested dicts
+                label = QtWidgets.QLabel(f"<b>{key}:</b>")
+                self.form_layout.addRow(label)
+                self._build_form(value, full_key)
+            else:
+                # Create appropriate widget for the value
+                is_readonly = full_key in self.readonly_keys
+                widget = self._create_widget(value, is_readonly)
+                self.field_widgets[full_key] = (widget, value)
+                
+                # Create label with tooltip if available
+                label = QtWidgets.QLabel(f"{key}:")
+                # Try multiple key formats to find tooltip
+                tooltip = None
+                if key in self.field_tooltips:
+                    tooltip = self.field_tooltips[key]
+                elif full_key in self.field_tooltips:
+                    tooltip = self.field_tooltips[full_key]
+                
+                # Always set a tooltip, even if empty, so users know hover works
+                if tooltip:
+                    label.setToolTip(tooltip)
+                    print(f"DEBUG: Set tooltip for {key}: {tooltip}")
+                else:
+                    label.setToolTip("(no description available)")
+                    print(f"DEBUG: No tooltip for {key} (tried: {key}, {full_key})")
+                
+                self.form_layout.addRow(label, widget)
+    
+    def _create_widget(self, value, readonly=False):
+        """Create appropriate widget based on value type"""
+        if isinstance(value, bool):
+            widget = QtWidgets.QCheckBox()
+            widget.setChecked(value)
+            widget.setEnabled(not readonly)
+        elif isinstance(value, list):
+            widget = QtWidgets.QLineEdit()
+            # Convert list to comma-separated string for editing
+            widget.setText(", ".join(str(v) for v in value))
+            widget.setReadOnly(readonly)
+        elif isinstance(value, (int, float)):
+            widget = QtWidgets.QLineEdit()
+            widget.setText(str(value))
+            widget.setReadOnly(readonly)
+        else:  # string or other
+            # Check if this is a string with units (e.g., "5 mm", "10 second", "0.5 Hz")
+            str_value = str(value)
+            unit_pattern = r'^([\d\.\-e]+)\s+(mm|second|seconds|Hz|micromolar\*\*2|micromolar)$'
+            match = re.match(unit_pattern, str_value)
+            
+            if match and not readonly:
+                # Create a composite widget with editable number and read-only unit
+                widget = QtWidgets.QWidget()
+                layout = QtWidgets.QHBoxLayout()
+                layout.setContentsMargins(0, 0, 0, 0)
+                layout.setSpacing(5)
+                
+                # Editable number field
+                number_field = QtWidgets.QLineEdit()
+                number_field.setText(match.group(1))
+                number_field.setMaximumWidth(100)
+                layout.addWidget(number_field)
+                
+                # Read-only unit label
+                unit_label = QtWidgets.QLabel(match.group(2))
+                unit_label.setStyleSheet("color: #666; background-color: #f0f0f0; padding: 3px 8px; border: 1px solid #ccc; border-radius: 3px;")
+                layout.addWidget(unit_label)
+                
+                layout.addStretch()
+                widget.setLayout(layout)
+                
+                # Store references for later retrieval
+                widget._number_field = number_field
+                widget._unit = match.group(2)
+            else:
+                # Regular string field
+                widget = QtWidgets.QLineEdit()
+                widget.setText(str_value)
+                widget.setReadOnly(readonly)
+        
+        if readonly and isinstance(widget, QtWidgets.QLineEdit):
+            widget.setStyleSheet("background-color: #f0f0f0;")
+        
+        return widget
+    
+    def get_updated_data(self):
+        """Extract updated values from form widgets"""
+        updated = {}
+        
+        for full_key, (widget, original_value) in self.field_widgets.items():
+            keys = full_key.split('.')
+            
+            # Get the new value from widget
+            if isinstance(widget, QtWidgets.QCheckBox):
+                new_value = widget.isChecked()
+            elif isinstance(widget, QtWidgets.QLineEdit):
+                text = widget.text().strip()
+                if isinstance(original_value, list):
+                    # Parse comma-separated list back to original format
+                    new_value = [v.strip().strip('"\'') for v in text.split(',') if v.strip()]
+                elif isinstance(original_value, int):
+                    try:
+                        new_value = int(text)
+                    except ValueError:
+                        new_value = original_value
+                elif isinstance(original_value, float):
+                    try:
+                        new_value = float(text)
+                    except ValueError:
+                        new_value = original_value
+                else:
+                    new_value = text
+            elif hasattr(widget, '_number_field') and hasattr(widget, '_unit'):
+                # This is a composite widget with units
+                number_text = widget._number_field.text().strip()
+                unit = widget._unit
+                new_value = f"{number_text} {unit}"
+            else:
+                continue
+            
+            # Build nested dict structure
+            current = updated
+            for i, key in enumerate(keys[:-1]):
+                if key not in current:
+                    current[key] = {}
+                current = current[key]
+            current[keys[-1]] = new_value
+        
+        return updated
+
+
+class SnakemakeSetupDialog(QtWidgets.QDialog):
+    """Dialog for setting up Snakemake pipeline (selecting Snakefile and loading config)"""
+    
+    def __init__(self, parent=None, current_snakefile=None, current_config=None):
+        super().__init__(parent)
+        self.snakefile_path = current_snakefile or ""
+        self.config_path = current_config or ""
+        
+        self.setWindowTitle("Setup Snakemake Pipeline")
+        self.setMinimumWidth(600)
+        
+        self.init_ui()
+    
+    def init_ui(self):
+        layout = QtWidgets.QVBoxLayout()
+        form_layout = QtWidgets.QFormLayout()
+        
+        # Snakefile path
+        snakefile_layout = QtWidgets.QHBoxLayout()
+        self.snakefile_edit = QtWidgets.QLineEdit()
+        if self.snakefile_path:
+            self.snakefile_edit.setText(self.snakefile_path)
+        else:
+            self.snakefile_edit.setPlaceholderText("Path to Snakefile")
+        snakefile_browse_btn = QtWidgets.QPushButton("Browse...")
+        snakefile_browse_btn.clicked.connect(self._browse_snakefile)
+        snakefile_layout.addWidget(self.snakefile_edit)
+        snakefile_layout.addWidget(snakefile_browse_btn)
+        form_layout.addRow("Snakefile:", snakefile_layout)
+        
+        # Config file path
+        config_layout = QtWidgets.QHBoxLayout()
+        self.config_edit = QtWidgets.QLineEdit()
+        if self.config_path:
+            self.config_edit.setText(self.config_path)
+        else:
+            self.config_edit.setPlaceholderText("Auto-detected from Snakefile location")
+        config_browse_btn = QtWidgets.QPushButton("Browse...")
+        config_browse_btn.clicked.connect(self._browse_config)
+        config_layout.addWidget(self.config_edit)
+        config_layout.addWidget(config_browse_btn)
+        form_layout.addRow("Config File:", config_layout)
+        
+        layout.addLayout(form_layout)
+        
+        # Info label
+        info_label = QtWidgets.QLabel(
+            "Select a Snakefile to load its configuration.\n"
+            "Config file will be auto-detected from: <snakefile_dir>/config/<snakefile>.yaml"
+        )
+        info_label.setWordWrap(True)
+        info_label.setStyleSheet("color: gray; font-size: 10pt;")
+        layout.addWidget(info_label)
+        
+        layout.addStretch()
+        
+        # Add buttons
+        button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        button_box.accepted.connect(self._validate_and_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+        
+        self.setLayout(layout)
+    
+    def _browse_snakefile(self):
+        file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Select Snakefile",
+            "",
+            "Snakefile (Snakefile);;All Files (*)"
+        )
+        if file_path:
+            self.snakefile_edit.setText(file_path)
+            self._auto_detect_config(file_path)
+    
+    def _browse_config(self):
+        file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Select Config File",
+            "",
+            "YAML Files (*.yaml *.yml);;All Files (*)"
+        )
+        if file_path:
+            self.config_edit.setText(file_path)
+    
+    def _auto_detect_config(self, snakefile_path):
+        """Auto-detect config file based on Snakefile location"""
+        snakefile_dir = os.path.dirname(snakefile_path)
+        snakefile_name = os.path.basename(snakefile_path)
+        
+        # Look for config/<snakefile_name>.yaml
+        config_dir = os.path.join(snakefile_dir, 'config')
+        if os.path.exists(config_dir):
+            config_file = os.path.join(config_dir, f"{snakefile_name}.yaml")
+            if os.path.exists(config_file):
+                self.config_edit.setText(config_file)
+                return
+        
+        # Clear if nothing found
+        self.config_edit.clear()
+    
+    def _validate_and_accept(self):
+        self.snakefile_path = self.snakefile_edit.text().strip()
+        self.config_path = self.config_edit.text().strip()
+        
+        # Auto-detect config if not specified
+        if not self.config_path and self.snakefile_path:
+            snakefile_dir = os.path.dirname(self.snakefile_path)
+            snakefile_name = os.path.basename(self.snakefile_path)
+            config_file = os.path.join(snakefile_dir, 'config', f"{snakefile_name}.yaml")
+            if os.path.exists(config_file):
+                self.config_path = config_file
+        
+        if not self.snakefile_path:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Missing Snakefile",
+                "Please specify the path to the Snakefile."
+            )
+            return
+        
+        if not os.path.exists(self.snakefile_path):
+            QtWidgets.QMessageBox.warning(
+                self,
+                "File Not Found",
+                f"Snakefile not found at:\n{self.snakefile_path}"
+            )
+            return
+        
+        if not self.config_path:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Missing Config",
+                "Could not auto-detect config file. Please specify it manually."
+            )
+            return
+        
+        if not os.path.exists(self.config_path):
+            QtWidgets.QMessageBox.warning(
+                self,
+                "File Not Found",
+                f"Config file not found at:\n{self.config_path}"
+            )
+            return
+        
+        self.accept()
+
+
+class SnakemakeRunDialog(QtWidgets.QDialog):
+    """Dialog for running Snakemake pipeline (simplified - assumes setup already done)"""
+    
+    def __init__(self, parent=None, current_subject=None, current_run=None):
+        super().__init__(parent)
+        self.current_subject = current_subject
+        self.current_run = current_run
+        
+        self.setWindowTitle("Run Snakemake Pipeline")
+        self.setMinimumWidth(500)
+        
+        self.init_ui()
+    
+    def _get_snakefile_rules(self, snakefile_path):
+        """Extract available rules from Snakefile"""
+        if not snakefile_path or not os.path.exists(snakefile_path):
+            return []
+        
+        rules = []
+        try:
+            with open(snakefile_path, 'r') as f:
+                content = f.read()
+            
+            # Find all rule definitions using regex
+            import re
+            # Match: rule rule_name:
+            rule_matches = re.finditer(r'^rule\s+(\w+)\s*:', content, re.MULTILINE)
+            for match in rule_matches:
+                rule_name = match.group(1)
+                if rule_name not in rules:
+                    rules.append(rule_name)
+            
+            print(f"Found {len(rules)} rules in Snakefile: {rules}")
+        except Exception as e:
+            print(f"Error parsing Snakefile: {e}")
+        
+        return rules
+    
+    def _get_conda_environments(self):
+        """Get list of available conda environments."""
+        import subprocess
+        import shutil
+        environments = []
+        error_msg = None
+        
+        # Try to find conda executable
+        conda_cmd = None
+        
+        # First, try standard PATH lookup
+        for cmd in ['conda', 'conda.bat', 'conda.exe']:
+            if shutil.which(cmd):
+                conda_cmd = cmd
+                print(f"DEBUG: Found conda in PATH: {conda_cmd}")
+                break
+        
+        # If not in PATH, try common installation locations
+        if not conda_cmd:
+            print("DEBUG: conda not in PATH, checking common installation locations...")
+            possible_paths = []
+            
+            # Windows common locations
+            if sys.platform == 'win32':
+                user_home = os.path.expanduser('~')
+                possible_paths = [
+                    os.path.join(user_home, 'anaconda3', 'Scripts', 'conda.exe'),
+                    os.path.join(user_home, 'Anaconda3', 'Scripts', 'conda.exe'),
+                    os.path.join(user_home, 'miniconda3', 'Scripts', 'conda.exe'),
+                    os.path.join(user_home, 'Miniconda3', 'Scripts', 'conda.exe'),
+                    r'C:\ProgramData\anaconda3\Scripts\conda.exe',
+                    r'C:\ProgramData\Anaconda3\Scripts\conda.exe',
+                    r'C:\ProgramData\miniconda3\Scripts\conda.exe',
+                    r'C:\tools\anaconda3\Scripts\conda.exe',
+                    r'C:\tools\miniconda3\Scripts\conda.exe',
+                ]
+            else:
+                # Unix/Mac common locations
+                user_home = os.path.expanduser('~')
+                possible_paths = [
+                    os.path.join(user_home, 'anaconda3', 'bin', 'conda'),
+                    os.path.join(user_home, 'miniconda3', 'bin', 'conda'),
+                    os.path.join(user_home, 'opt', 'anaconda3', 'bin', 'conda'),
+                    os.path.join(user_home, 'opt', 'miniconda3', 'bin', 'conda'),
+                    '/opt/anaconda3/bin/conda',
+                    '/opt/miniconda3/bin/conda',
+                    '/usr/local/anaconda3/bin/conda',
+                    '/usr/local/miniconda3/bin/conda',
+                ]
+            
+            for path in possible_paths:
+                if os.path.isfile(path):
+                    conda_cmd = path
+                    print(f"DEBUG: Found conda at: {conda_cmd}")
+                    break
+        
+        if not conda_cmd:
+            error_msg = "conda command not found in PATH or common installation locations."
+            print(f"ERROR: {error_msg}")
+            print("DEBUG: Checked for: conda, conda.bat, conda.exe in PATH")
+            print(f"DEBUG: Checked {len(possible_paths) if 'possible_paths' in locals() else 0} common installation paths")
+            print(f"DEBUG: System PATH: {os.environ.get('PATH', 'N/A')[:200]}...")
+            print("HINT: If conda works in terminal, try running the GUI from an Anaconda/Miniconda prompt")
+            # Return fallback defaults
+            return ["cedalion_snakemake", "cedalion_snakemake_dev"]
+        
+        try:
+            print(f"DEBUG: Using conda command: {conda_cmd}")
+            result = subprocess.run(
+                [conda_cmd, 'env', 'list'],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                shell=(sys.platform == 'win32')  # Use shell on Windows for .bat files
+            )
+            
+            print(f"DEBUG: conda env list return code: {result.returncode}")
+            print(f"DEBUG: conda env list stdout length: {len(result.stdout)}")
+            if result.stderr:
+                print(f"DEBUG: conda env list stderr: {result.stderr[:200]}")
+            
+            if result.returncode == 0:
+                # Parse output to extract environment names
+                for line in result.stdout.splitlines():
+                    line = line.strip()
+                    # Skip comments and empty lines
+                    if line and not line.startswith('#'):
+                        # Environment name is the first word
+                        parts = line.split()
+                        if parts:
+                            env_name = parts[0]
+                            # Skip base environment marker (*)
+                            if env_name != '*':
+                                environments.append(env_name)
+                
+                print(f"DEBUG: Found {len(environments)} conda environments")
+                if environments:
+                    print(f"DEBUG: Environments: {environments[:5]}...")  # Show first 5
+            else:
+                error_msg = f"conda env list failed with return code {result.returncode}"
+                print(f"ERROR: {error_msg}")
+                
+        except subprocess.TimeoutExpired:
+            error_msg = "conda env list command timed out after 10 seconds"
+            print(f"ERROR: {error_msg}")
+        except FileNotFoundError as e:
+            error_msg = f"conda executable not found: {e}"
+            print(f"ERROR: {error_msg}")
+        except Exception as e:
+            error_msg = f"Unexpected error getting conda environments: {e}"
+            print(f"ERROR: {error_msg}")
+            import traceback
+            traceback.print_exc()
+        
+        # If we got an error or no environments, return fallback
+        if not environments:
+            print(f"WARNING: Falling back to default environment list")
+            if error_msg:
+                print(f"Reason: {error_msg}")
+            return ["cedalion_snakemake", "cedalion_snakemake_dev"]
+        
+        return environments
+    
+    def _get_current_conda_environment(self):
+        """Get the currently active conda environment name."""
+        # Check CONDA_DEFAULT_ENV environment variable
+        current_env = os.environ.get('CONDA_DEFAULT_ENV', None)
+        if current_env:
+            print(f"DEBUG: Current conda environment: {current_env}")
+            return current_env
+        
+        # Fallback: try to detect from CONDA_PREFIX
+        conda_prefix = os.environ.get('CONDA_PREFIX', None)
+        if conda_prefix:
+            # Extract environment name from path (last folder)
+            env_name = os.path.basename(conda_prefix)
+            print(f"DEBUG: Current conda environment from CONDA_PREFIX: {env_name}")
+            return env_name
+        
+        print("DEBUG: No active conda environment detected")
+        return None
+
+    def init_ui(self):
+        layout = QtWidgets.QVBoxLayout()
+        form_layout = QtWidgets.QFormLayout()
+        
+        # Run on current selection checkbox
+        self.current_selection_checkbox = QtWidgets.QCheckBox("Run on current selection only")
+        if self.current_subject and self.current_run:
+            self.current_selection_checkbox.setEnabled(True)
+            self.current_selection_checkbox.setToolTip(f"Run only for {self.current_subject}, {self.current_run}")
+        else:
+            self.current_selection_checkbox.setEnabled(False)
+            self.current_selection_checkbox.setToolTip("No selection available")
+        form_layout.addRow("", self.current_selection_checkbox)
+        
+        # Dry run checkbox
+        self.dry_run_checkbox = QtWidgets.QCheckBox("Dry run (-n)")
+        self.dry_run_checkbox.setChecked(True)
+        self.dry_run_checkbox.setToolTip("Preview what will be run without executing")
+        form_layout.addRow("", self.dry_run_checkbox)
+        
+        # Unlock checkbox
+        self.unlock_checkbox = QtWidgets.QCheckBox("Unlock directory (--unlock)")
+        self.unlock_checkbox.setChecked(False)
+        self.unlock_checkbox.setToolTip("Remove locks from previous interrupted runs")
+        form_layout.addRow("", self.unlock_checkbox)
+        
+        # Rerun incomplete checkbox
+        self.rerun_incomplete_checkbox = QtWidgets.QCheckBox("Rerun incomplete files (--rerun-incomplete)")
+        self.rerun_incomplete_checkbox.setChecked(False)
+        self.rerun_incomplete_checkbox.setToolTip("Regenerate incomplete files from interrupted runs")
+        form_layout.addRow("", self.rerun_incomplete_checkbox)
+        
+        # Summary checkbox
+        self.summary_checkbox = QtWidgets.QCheckBox("Show summary (--summary)")
+        self.summary_checkbox.setChecked(False)
+        self.summary_checkbox.setToolTip("Show summary of all output files with their status (ok, missing, needs update)")
+        form_layout.addRow("", self.summary_checkbox)
+        
+        # Target rule selector
+        target_layout = QtWidgets.QHBoxLayout()
+        self.target_combo = QtWidgets.QComboBox()
+        
+        # Get available rules from Snakefile if parent has the info
+        available_rules = []
+        if self.parent() and hasattr(self.parent(), 'snakefile_path'):
+            available_rules = self._get_snakefile_rules(self.parent().snakefile_path)
+        
+        # Populate with available rules, or use defaults
+        if available_rules:
+            for rule in available_rules:
+                self.target_combo.addItem(rule, rule)
+        else:
+            # Fallback to default options
+            self.target_combo.addItem("all_default", "all_default")
+            self.target_combo.addItem("all_groupaverage", "all_groupaverage")
+        
+        self.target_combo.setEditable(True)
+        self.target_combo.setCurrentIndex(0)
+        self.target_combo.setToolTip("Select which Snakemake target rule to run")
+        target_layout.addWidget(self.target_combo)
+        target_layout.addStretch()
+        form_layout.addRow("Target rule:", target_layout)
+        
+        # Number of cores with "all" option - dynamically based on system
+        cores_layout = QtWidgets.QHBoxLayout()
+        self.cores_combo = QtWidgets.QComboBox()
+        self.cores_combo.addItem("all")
+        
+        # Get available CPU count
+        try:
+            cpu_count = psutil.cpu_count(logical=True)
+            # Generate core options: 1, 2, 4, 8, ... up to available cores
+            core_options = [1, 2, 4, 8, 16, 32, 64, 128]
+            for i in core_options:
+                if i <= cpu_count:
+                    self.cores_combo.addItem(str(i))
+                else:
+                    break
+            # If CPU count doesn't match any of the powers of 2, add it
+            if cpu_count not in core_options:
+                self.cores_combo.addItem(str(cpu_count))
+        except:
+            # Fallback if psutil fails
+            for i in [1, 2, 4, 8, 16]:
+                self.cores_combo.addItem(str(i))
+        
+        self.cores_combo.setEditable(True)
+        self.cores_combo.setCurrentText("1")
+        cores_layout.addWidget(self.cores_combo)
+        cores_layout.addStretch()
+        form_layout.addRow("Cores:", cores_layout)
+        
+        # Conda environment selector
+        env_layout = QtWidgets.QHBoxLayout()
+        self.env_combo = QtWidgets.QComboBox()
+        
+        # Get available conda environments
+        conda_envs = self._get_conda_environments()
+        for env in conda_envs:
+            self.env_combo.addItem(env)
+        
+        self.env_combo.setEditable(True)
+        
+        # Set default to currently active environment, otherwise cedalion_snakemake, otherwise first in list
+        current_env = self._get_current_conda_environment()
+        if current_env and current_env in conda_envs:
+            self.env_combo.setCurrentText(current_env)
+            print(f"DEBUG: Set default environment to current: {current_env}")
+        elif "cedalion_snakemake" in conda_envs:
+            self.env_combo.setCurrentText("cedalion_snakemake")
+            print(f"DEBUG: Set default environment to cedalion_snakemake (current env not found)")
+        else:
+            self.env_combo.setCurrentIndex(0)
+            print(f"DEBUG: Set default environment to first in list")
+        
+        self.env_combo.setToolTip("Select conda environment to use for running Snakemake")
+        env_layout.addWidget(self.env_combo)
+        env_layout.addStretch()
+        form_layout.addRow("Conda Environment:", env_layout)
+        
+        layout.addLayout(form_layout)
+        
+        # Add buttons
+        button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+        
+        self.setLayout(layout)
+
+
+class SummaryWorker(QtCore.QThread):
+    """Background worker thread for running snakemake --summary command"""
+    summary_completed = QtCore.Signal(dict)  # Emits file_status_map
+    summary_failed = QtCore.Signal(str)  # Emits error message
+    
+    def __init__(self, snakefile_path, config_path, conda_env=None, target_rule='all_default'):
+        super().__init__()
+        self.snakefile_path = snakefile_path
+        self.config_path = config_path
+        self.conda_env = conda_env
+        self.target_rule = target_rule
+        self._is_canceled = False
+    
+    def cancel(self):
+        """Cancel the worker thread"""
+        self._is_canceled = True
+    
+    def run(self):
+        """Run the summary command in background thread"""
+        if self._is_canceled:
+            return
+            
+        try:
+            file_status_map = self._run_snakemake_summary_impl()
+            if not self._is_canceled:
+                self.summary_completed.emit(file_status_map)
+        except Exception as e:
+            if not self._is_canceled:
+                self.summary_failed.emit(str(e))
+    
+    def _run_snakemake_summary_impl(self):
+        """Implementation of snakemake summary command (runs in background thread)"""
+        try:
+            # Build command with conda activation if environment is set
+            if self.conda_env:
+                cmd = ['conda', 'run', '-n', self.conda_env, '--no-capture-output',
+                       'snakemake', '-s', self.snakefile_path,
+                       '--configfile', self.config_path, '--nolock', '--summary', self.target_rule]
+            else:
+                cmd = ['snakemake', '-s', self.snakefile_path,
+                       '--configfile', self.config_path, '--nolock', '--summary', self.target_rule]
+            
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=os.path.dirname(self.snakefile_path)
+            )
+            
+            if self._is_canceled:
+                return {}
+            
+            if result.returncode != 0:
+                print(f"WARNING: snakemake --summary returned error code {result.returncode}")
+                print(f"STDERR: {result.stderr}")
+                return {}
+            
+            # Parse the summary output (tab-delimited table)
+            file_status_map = {}
+            lines = result.stdout.strip().split('\n')
+            
+            if len(lines) < 2:
+                print("WARNING: Summary output has fewer than 2 lines")
+                return {}
+            
+            # Skip header line
+            for line in lines[1:]:
+                if self._is_canceled:
+                    return {}
+                    
+                if not line.strip():
+                    continue
+                
+                # Split by tabs to handle multi-word values
+                parts = line.split('\t')
+                if len(parts) < 6:
+                    continue
+                
+                # Extract: output file, date, rule, log-file(s), status, plan
+                file_path = parts[0].strip()
+                status = parts[4].strip()
+                plan = parts[5].strip()
+                
+                # Normalize path for consistent comparison
+                file_path = os.path.normpath(file_path)
+                
+                file_status_map[file_path] = {
+                    'status': status,
+                    'plan': plan
+                }
+            
+            return file_status_map
+            
+        except Exception as e:
+            print(f"Error running snakemake summary: {str(e)}")
+            return {}
+
+
+class ImageReconDialog(QtWidgets.QDialog):
+    """Dialog for selecting image reconstruction options"""
+    def __init__(self, trial_types, is_group_avg=False, time_bounds=None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Image Reconstruction Options")
+        self.setModal(False)  # Non-modal so it doesn't block and can stay open
+        self.setMinimumWidth(450)
+        self.setMinimumHeight(600)
+        self.launch_callback = None  # Will be set by parent
+        self.widgets_to_protect = []  # Track widgets that need scroll protection
+        self.is_group_avg = is_group_avg  # Track if this is group average data
+        self.time_bounds = time_bounds if time_bounds else (-100, 100)  # (min, max)
+        
+        main_layout = QtWidgets.QVBoxLayout()
+        
+        # Create scroll area for all options
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll_widget = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout()
+        scroll_widget.setLayout(layout)
+        scroll.setWidget(scroll_widget)
+        
+        # Trial Type Selection
+        trial_type_group = QtWidgets.QGroupBox("Trial Type")
+        trial_type_layout = QtWidgets.QVBoxLayout()
+        self.trial_type_combo = QtWidgets.QComboBox()
+        self.trial_type_combo.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.trial_type_combo.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.trial_type_combo)
+        self.trial_type_combo.addItems(trial_types)
+        trial_type_layout.addWidget(self.trial_type_combo)
+        trial_type_group.setLayout(trial_type_layout)
+        layout.addWidget(trial_type_group)
+        
+        # View Type Selection (includes both chromophore and surface type)
+        view_type_group = QtWidgets.QGroupBox("View Type")
+        view_type_layout = QtWidgets.QVBoxLayout()
+        self.view_type_combo = QtWidgets.QComboBox()
+        self.view_type_combo.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.view_type_combo.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.view_type_combo)
+        self.view_type_combo.addItems([
+            "hbo_brain", "hbr_brain", 
+            "hbo_scalp", "hbr_scalp"
+        ])
+        view_type_layout.addWidget(self.view_type_combo)
+        view_type_group.setLayout(view_type_layout)
+        layout.addWidget(view_type_group)
+        
+        # Metric Selection
+        metric_group = QtWidgets.QGroupBox("Metric")
+        metric_layout = QtWidgets.QVBoxLayout()
+        self.metric_combo = QtWidgets.QComboBox()
+        self.metric_combo.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.metric_combo.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.metric_combo)
+        
+        # Populate metric options based on group average flag
+        if self.is_group_avg:
+            self.metric_combo.addItems([
+                "mag",
+                "std_err",
+                "t_stat",
+                "std_err_btwn_subjs",
+                "std_err_within_subjs"
+            ])
+        else:
+            self.metric_combo.addItems([
+                "mag",
+                "std_err",
+                "t_stat"
+            ])
+        
+        metric_layout.addWidget(self.metric_combo)
+        metric_group.setLayout(metric_layout)
+        layout.addWidget(metric_group)
+        
+        # View Mode and Position Selection
+        view_mode_group = QtWidgets.QGroupBox("View Mode")
+        view_mode_layout = QtWidgets.QVBoxLayout()
+        
+        self.multi_view = QtWidgets.QCheckBox("Multi-view (6 views)")
+        self.multi_view.setChecked(True)
+        self.multi_view.stateChanged.connect(self._toggle_view_position)
+        view_mode_layout.addWidget(self.multi_view)
+        
+        view_pos_layout = QtWidgets.QHBoxLayout()
+        view_pos_layout.addWidget(QtWidgets.QLabel("Single View Position:"))
+        self.view_position_combo = QtWidgets.QComboBox()
+        self.view_position_combo.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.view_position_combo.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.view_position_combo)
+        self.view_position_combo.addItems([
+            "superior", "left", "right", 
+            "anterior", "posterior", "inferior"
+        ])
+        self.view_position_combo.setEnabled(False)
+        view_pos_layout.addWidget(self.view_position_combo)
+        view_mode_layout.addLayout(view_pos_layout)
+        
+        view_mode_group.setLayout(view_mode_layout)
+        layout.addWidget(view_mode_group)
+        
+        # Colormap Selection
+        cmap_group = QtWidgets.QGroupBox("Colormap")
+        cmap_layout = QtWidgets.QVBoxLayout()
+        self.cmap_combo = QtWidgets.QComboBox()
+        self.cmap_combo.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.cmap_combo.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.cmap_combo)
+        self.cmap_combo.addItems(["seismic", "RdBu_r", "viridis", "coolwarm", "jet"])
+        cmap_layout.addWidget(self.cmap_combo)
+        cmap_group.setLayout(cmap_layout)
+        layout.addWidget(cmap_group)
+        
+        # Color Limits (clim)
+        clim_group = QtWidgets.QGroupBox("Color Limits")
+        clim_layout = QtWidgets.QGridLayout()
+        
+        self.auto_clim = QtWidgets.QCheckBox("Auto (99th percentile)")
+        self.auto_clim.setChecked(True)
+        self.auto_clim.stateChanged.connect(self._toggle_clim_inputs)
+        clim_layout.addWidget(self.auto_clim, 0, 0, 1, 2)
+        
+        clim_layout.addWidget(QtWidgets.QLabel("Min:"), 1, 0)
+        self.clim_min = QtWidgets.QDoubleSpinBox()
+        self.clim_min.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.clim_min.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.clim_min)
+        self.clim_min.setRange(-1e6, 1e6)
+        self.clim_min.setValue(-1e-5)
+        self.clim_min.setDecimals(8)
+        self.clim_min.setSingleStep(1e-6)
+        self.clim_min.setEnabled(False)
+        clim_layout.addWidget(self.clim_min, 1, 1)
+        
+        clim_layout.addWidget(QtWidgets.QLabel("Max:"), 2, 0)
+        self.clim_max = QtWidgets.QDoubleSpinBox()
+        self.clim_max.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.clim_max.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.clim_max)
+        self.clim_max.setRange(-1e6, 1e6)
+        self.clim_max.setValue(1e-5)
+        self.clim_max.setDecimals(8)
+        self.clim_max.setSingleStep(1e-6)
+        self.clim_max.setEnabled(False)
+        clim_layout.addWidget(self.clim_max, 2, 1)
+        
+        clim_group.setLayout(clim_layout)
+        layout.addWidget(clim_group)
+        
+        # Time Range Selection
+        time_range_group = QtWidgets.QGroupBox("Time Range (seconds)")
+        time_range_layout = QtWidgets.QGridLayout()
+        
+        # Display available time bounds
+        min_time, max_time = self.time_bounds
+        bounds_label = QtWidgets.QLabel(f"Available: {min_time:.1f} to {max_time:.1f}s")
+        bounds_label.setStyleSheet("color: gray; font-style: italic;")
+        time_range_layout.addWidget(bounds_label, 0, 0, 1, 2)
+        
+        time_range_layout.addWidget(QtWidgets.QLabel("Start:"), 1, 0)
+        self.time_start = QtWidgets.QDoubleSpinBox()
+        self.time_start.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.time_start.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.time_start)
+        self.time_start.setRange(min_time, max_time)
+        self.time_start.setValue(max(min_time, -2))  # Default to -2 or min_time if larger
+        self.time_start.setSingleStep(0.5)
+        self.time_start.valueChanged.connect(self._validate_time_range)
+        time_range_layout.addWidget(self.time_start, 1, 1)
+        
+        time_range_layout.addWidget(QtWidgets.QLabel("End:"), 2, 0)
+        self.time_end = QtWidgets.QDoubleSpinBox()
+        self.time_end.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.time_end.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.time_end)
+        self.time_end.setRange(min_time, max_time)
+        self.time_end.setValue(min(max_time, 35))  # Default to 35 or max_time if smaller
+        self.time_end.setSingleStep(0.5)
+        self.time_end.valueChanged.connect(self._validate_time_range)
+        time_range_layout.addWidget(self.time_end, 2, 1)
+        
+        time_range_layout.addWidget(QtWidgets.QLabel("Step:"), 3, 0)
+        self.time_step = QtWidgets.QDoubleSpinBox()
+        self.time_step.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.time_step.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.time_step)
+        self.time_step.setRange(0.1, 10)
+        self.time_step.setValue(0.5)
+        self.time_step.setSingleStep(0.1)
+        time_range_layout.addWidget(self.time_step, 3, 1)
+        
+        self.mean_over_time = QtWidgets.QCheckBox("Mean over time range")
+        self.mean_over_time.setChecked(False)
+        self.mean_over_time.stateChanged.connect(self._toggle_mean_time_range)
+        time_range_layout.addWidget(self.mean_over_time, 4, 0, 1, 2)
+        
+        time_range_group.setLayout(time_range_layout)
+        layout.addWidget(time_range_group)
+        
+        # FPS for animation
+        fps_group = QtWidgets.QGroupBox("Animation")
+        fps_layout = QtWidgets.QHBoxLayout()
+        fps_layout.addWidget(QtWidgets.QLabel("FPS:"))
+        self.fps_spin = QtWidgets.QSpinBox()
+        self.fps_spin.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.fps_spin.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.fps_spin)
+        self.fps_spin.setRange(1, 30)
+        self.fps_spin.setValue(6)
+        fps_layout.addWidget(self.fps_spin)
+        fps_group.setLayout(fps_layout)
+        layout.addWidget(fps_group)
+        
+        # Window Size
+        wdw_group = QtWidgets.QGroupBox("Window Size (pixels)")
+        wdw_layout = QtWidgets.QGridLayout()
+        
+        wdw_layout.addWidget(QtWidgets.QLabel("Width:"), 0, 0)
+        self.wdw_width = QtWidgets.QSpinBox()
+        self.wdw_width.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.wdw_width.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.wdw_width)
+        self.wdw_width.setRange(400, 3840)
+        self.wdw_width.setValue(1024)
+        self.wdw_width.setSingleStep(100)
+        wdw_layout.addWidget(self.wdw_width, 0, 1)
+        
+        wdw_layout.addWidget(QtWidgets.QLabel("Height:"), 1, 0)
+        self.wdw_height = QtWidgets.QSpinBox()
+        self.wdw_height.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.wdw_height.installEventFilter(self)  # Block scroll when not focused
+        self.widgets_to_protect.append(self.wdw_height)
+        self.wdw_height.setRange(300, 2160)
+        self.wdw_height.setValue(768)
+        self.wdw_height.setSingleStep(100)
+        wdw_layout.addWidget(self.wdw_height, 1, 1)
+        
+        wdw_group.setLayout(wdw_layout)
+        layout.addWidget(wdw_group)
+        
+        # Display Options
+        display_group = QtWidgets.QGroupBox("Display Options")
+        display_layout = QtWidgets.QVBoxLayout()
+        
+        self.show_geo3d = QtWidgets.QCheckBox("Show labeled points (if available)")
+        self.show_geo3d.setChecked(False)
+        display_layout.addWidget(self.show_geo3d)
+        
+        self.custom_title = QtWidgets.QCheckBox("Custom title")
+        self.custom_title.setChecked(False)
+        self.custom_title.stateChanged.connect(self._toggle_title_input)
+        display_layout.addWidget(self.custom_title)
+        
+        self.title_input = QtWidgets.QLineEdit()
+        self.title_input.setPlaceholderText("Custom plot title")
+        self.title_input.setEnabled(False)
+        display_layout.addWidget(self.title_input)
+        
+        display_group.setLayout(display_layout)
+        layout.addWidget(display_group)
+        
+        # Save option
+        save_group = QtWidgets.QGroupBox("Output")
+        save_layout = QtWidgets.QVBoxLayout()
+        self.save_checkbox = QtWidgets.QCheckBox("Save output (PNG/GIF)")
+        self.save_checkbox.setChecked(False)
+        self.save_checkbox.stateChanged.connect(self._toggle_filename_input)
+        save_layout.addWidget(self.save_checkbox)
+        
+        self.filename_input = QtWidgets.QLineEdit()
+        self.filename_input.setPlaceholderText("Filename (without extension)")
+        self.filename_input.setEnabled(False)
+        save_layout.addWidget(self.filename_input)
+        
+        save_group.setLayout(save_layout)
+        layout.addWidget(save_group)
+        
+        # Add scroll area to main layout
+        main_layout.addWidget(scroll)
+        
+        # Dialog buttons (outside scroll area)
+        button_layout = QtWidgets.QHBoxLayout()
+        self.ok_button = QtWidgets.QPushButton("Launch Viewer")
+        self.ok_button.clicked.connect(self._on_launch_clicked)
+        self.cancel_button = QtWidgets.QPushButton("Close")
+        self.cancel_button.clicked.connect(self.close)
+        button_layout.addWidget(self.ok_button)
+        button_layout.addWidget(self.cancel_button)
+        main_layout.addLayout(button_layout)
+        
+        self.setLayout(main_layout)
+        
+        # Initialize control states
+        self._toggle_clim_inputs()
+        self._toggle_title_input()
+        self._toggle_view_position()
+        self._toggle_mean_time_range()
+    
+    def _toggle_filename_input(self):
+        """Enable/disable filename input based on save checkbox"""
+        self.filename_input.setEnabled(self.save_checkbox.isChecked())
+    
+    def _toggle_clim_inputs(self):
+        """Enable/disable color limit inputs based on auto checkbox"""
+        enabled = not self.auto_clim.isChecked()
+        self.clim_min.setEnabled(enabled)
+        self.clim_max.setEnabled(enabled)
+    
+    def eventFilter(self, obj, event):
+        """Filter wheel events on widgets that don't have focus"""
+        if event.type() == QtCore.QEvent.Wheel:
+            if obj in self.widgets_to_protect and not obj.hasFocus():
+                return True  # Block the wheel event
+        return super().eventFilter(obj, event)
+    
+    def _toggle_title_input(self):
+        """Enable/disable title input based on custom title checkbox"""
+        self.title_input.setEnabled(self.custom_title.isChecked())
+    
+    def _toggle_view_position(self):
+        """Enable/disable view position based on multi-view checkbox"""
+        self.view_position_combo.setEnabled(not self.multi_view.isChecked())
+    
+    def _toggle_mean_time_range(self):
+        """Enable/disable step field based on mean over time checkbox"""
+        # Step is disabled when mean over time is checked
+        self.time_step.setEnabled(not self.mean_over_time.isChecked())
+    
+    def _validate_time_range(self):
+        """Ensure start time is less than end time"""
+        if self.time_start.value() >= self.time_end.value():
+            # Auto-adjust end to be greater than start
+            self.time_end.blockSignals(True)  # Prevent recursive signal
+            self.time_end.setValue(self.time_start.value() + 0.5)
+            self.time_end.blockSignals(False)
+    
+    def _on_launch_clicked(self):
+        """Handle Launch Viewer button click - trigger callback without closing dialog"""
+        if self.launch_callback:
+            options = self.get_options()
+            self.launch_callback(options)
+    
+    def get_options(self):
+        """Return selected options as a dictionary"""
+        options = {
+            'trial_type': self.trial_type_combo.currentText(),
+            'view_type': self.view_type_combo.currentText(),
+            'metric': self.metric_combo.currentText(),
+            'cmap': self.cmap_combo.currentText(),
+            'fps': self.fps_spin.value(),
+            'save': self.save_checkbox.isChecked(),
+            'filename': self.filename_input.text() if self.save_checkbox.isChecked() else None,
+            'wdw_size': (self.wdw_width.value(), self.wdw_height.value()),
+            'show_geo3d': self.show_geo3d.isChecked(),
+            'multi_view': self.multi_view.isChecked(),
+            'view_position': self.view_position_combo.currentText()
+        }
+        
+        # Time range - always included
+        options['time_range'] = (
+            self.time_start.value(),
+            self.time_end.value(),
+            self.time_step.value()
+        )
+        options['mean_over_time'] = self.mean_over_time.isChecked()
+        
+        # Color limits
+        if not self.auto_clim.isChecked():
+            options['clim'] = (self.clim_min.value(), self.clim_max.value())
+        else:
+            options['clim'] = None  # Will be auto-calculated
+        
+        # Custom title
+        if self.custom_title.isChecked() and self.title_input.text():
+            options['title_str'] = self.title_input.text()
+        else:
+            options['title_str'] = None  # Will be auto-generated
+        
+        return options
+
+
+class _MAIN_GUI(QtWidgets.QMainWindow):
+    def __init__(self, gui_data=None):
+        # Initialize
+        super().__init__()
+        
+        self.oftype = "pkl" # We'll assume the new format
+        self.subjects = gui_data.get("subjects", [])
+        self.subject_to_runs_map = gui_data.get("subject_to_runs_map", {})
+        self.file_map = gui_data.get("file_map", {})
+        self.path_to_data = gui_data.get("path_to_data")  # Store the selected derivatives/cedalion/XXX folder
+
+        # Caching mechanism
+        self.MAX_CACHE_SIZE = 10 # Max number of recordings to keep in memory
+        self.MEMORY_THRESHOLD = 500 * 1024 * 1024 # 500 MB in bytes
+        self.cache = OrderedDict()
+        self.selected = [] # Initialize selected here
+        self.snirfRec = None # Initialize here before UI setup
+        
+        # Snakemake pipeline state
+        self.snakefile_path = None
+        self.snakemake_config_path = None
+        self.snakemake_config = None
+        self.snakemake_menu = None  # Will be set during UI setup
+        self.dynamic_menu_actions = []  # Track dynamically created menu items
+        
+        # Pipeline monitoring
+        self.pipeline_monitor_timer = None
+        self.pipeline_status = {}
+        self.file_colors = {}  # Track colors for each (subject, run)
+        self.snakemake_process = None  # Track the Snakemake process
+        self.file_status_map = {}  # Map of file paths to their status from summary
+        self.current_scope_files = {}  # Files in current config scope from summary
+        self.all_scope_files = {}  # All possible files from full scope summary
+        self.expected_pipeline_outputs = set()  # Files expected from summary
+        self.completed_pipeline_outputs = set()  # Files that have been completed
+        self.summary_worker = None  # Background worker for running summary command
+        self.conda_env = None  # Track conda environment for pipeline execution
+        
+        # Track "Run on current selection only" mode
+        self.run_current_only_mode = False  # Whether we're in current selection mode
+        self.current_selection_subject = None  # Subject ID (e.g., "15")
+        self.current_selection_task = None  # Task name (e.g., "IWHD")
+        self.current_selection_run = None  # Run ID (e.g., "01")
+
+        self._UI_SETUP()
+        
+        # Try to auto-load Snakemake configuration from homer.config
+        self._auto_load_snakemake_config()
+        
+        # Restore pipeline state and update colors
+        self._restore_pipeline_state()
+        
+        # Get the initial recording
+        if self.subjects:
+            initial_subject = self.subjects[0]
+            if initial_subject in self.file_map and self.subject_to_runs_map.get(initial_subject):
+                 initial_run = self.subject_to_runs_map[initial_subject][0]
+                 self._update_recording_data(initial_subject, initial_run, subject_changed=True)
+
+        if self.snirfRec is None:
+             print("Warning: Could not load an initial recording.")
+        
+    
+    def closeEvent(self, event):
+        """Clean up resources when GUI is closed"""
+        # Stop monitoring
+        if self.pipeline_monitor_timer:
+            self.pipeline_monitor_timer.stop()
+        
+        # Cancel and wait for summary worker to finish
+        if self.summary_worker and self.summary_worker.isRunning():
+            print("Closing GUI: Waiting for background worker to finish...")
+            self.summary_worker.cancel()
+            self.summary_worker.wait(5000)  # Wait up to 5 seconds
+            if self.summary_worker.isRunning():
+                print("WARNING: Background worker did not stop, forcing termination")
+                self.summary_worker.terminate()
+        
+        # Accept the close event
+        event.accept()
+
+    def _load_events_from_tsv(self, snirf_path):
+        """Load stimulus events from a BIDS-style *_events.tsv file.
+        
+        Args:
+            snirf_path: Path to the SNIRF file. The events file is assumed to be
+                        in the same directory with _nirs.snirf replaced by _events.tsv
+        
+        Returns:
+            pd.DataFrame: DataFrame containing stimulus information with columns
+                          [onset, duration, value, trial_type], or None if file not found
+        """
+        try:
+            # Construct events.tsv path: replace _nirs.snirf with _events.tsv
+            events_path = snirf_path.replace("_nirs.snirf", "_events.tsv")
+            
+            if not os.path.exists(events_path):
+                print(f"No events file found at {events_path}")
+                return None
+            
+            # Read TSV file
+            df = pd.read_csv(events_path, sep='\t')
+            
+            # Ensure required columns exist
+            if 'onset' not in df.columns or 'trial_type' not in df.columns:
+                print(f"Events file {events_path} missing required columns (onset, trial_type)")
+                return None
+            
+            # Add duration column if missing (default to 0)
+            if 'duration' not in df.columns:
+                df['duration'] = 0.0
+            
+            # Add value column if missing (default to 1.0)
+            if 'value' not in df.columns:
+                df['value'] = 1.0
+            
+            # Ensure column order matches expected format
+            df = df[['onset', 'duration', 'value', 'trial_type']]
+            
+            print(f"Loaded {len(df)} events from {events_path}")
+            return df
+            
+        except Exception as e:
+            print(f"Failed to read events file: {e}")
+            return None
+
+    def _prepare_data(self, rec_amp, rec_processed=None):
+        """
+        Performs all initial calculations on a recording.
+        
+        Args:
+            rec_amp: Recording object with amplitude data from SNIRF
+            rec_processed: Optional dict with processed data from PKL (od, conc, etc.)
+        """
+        prepared = {}
+        prepared['snirfRec'] = rec_amp
+        prepared['optodes_drawn'] = False
+
+        # Get timeseries - prioritize amp from SNIRF
+        if 'amp' in rec_amp.timeseries:
+            prepared['snirfData'] = rec_amp.timeseries['amp']
+        else:
+            prepared['snirfData'] = rec_amp.timeseries[list(rec_amp.timeseries.keys())[0]]
+
+        sPos = rec_amp.geo2d.sel(label=["S" in str(s.values) for s in rec_amp.geo2d.label])
+        dPos = rec_amp.geo2d.sel(label=["D" in str(s.values) for s in rec_amp.geo2d.label])
+        prepared['sPos'] = sPos
+        prepared['dPos'] = dPos
+        prepared['sPosVal'] = sPos.values
+        prepared['dPosVal'] = dPos.values
+
+        prepared['slabel'] = sPos.label.values
+        prepared['dlabel'] = dPos.label.values
+        prepared['opt_label'] = np.append(sPos.label.values, dPos.label.values)
+
+        prepared['no_channels'] = len(prepared['snirfData'].channel)
+        prepared['no_wvls'] = len(prepared['snirfData'].wavelength)
+
+        prepared['channel_idx'] = np.arange(0, prepared['no_channels'])
+        prepared['src_idx'] = [
+            np.arange(0, len(sPos))[sPos.label == src][0]
+            for src in prepared['snirfData'].source
+        ]
+        prepared['det_idx'] = [
+            np.arange(0, len(dPos))[dPos.label == det][0]
+            for det in prepared['snirfData'].detector
+        ]
+
+        prepared['sx'] = prepared['sPosVal'][:, 0]
+        prepared['sy'] = prepared['sPosVal'][:, 1]
+        prepared['dx'] = prepared['dPosVal'][:, 0]
+        prepared['dy'] = prepared['dPosVal'][:, 1]
+
+        prepared['sdx'] = np.append(prepared['sx'], prepared['dx'])
+        prepared['sdy'] = np.append(prepared['sy'], prepared['dy'])
+
+        prepared['src_label_handles'] = [0] * len(prepared['sx'])
+        prepared['det_label_handles'] = [0] * len(prepared['dx'])
+        
+        # Get timeseries keys - combine from both sources if processed data exists
+        print(f"DEBUG _prepare_data: rec_processed type = {type(rec_processed)}")
+        print(f"DEBUG _prepare_data: rec_processed = {rec_processed}")
+        print(f"DEBUG _prepare_data: rec_amp.timeseries.keys() = {list(rec_amp.timeseries.keys())}")
+        
+        if rec_processed and hasattr(rec_processed, 'timeseries'):
+            # Merge timeseries from processed data (od, conc) with amp from SNIRF
+            print(f"DEBUG: rec_processed has timeseries: {list(rec_processed.timeseries.keys())}")
+            all_ts_keys = set(rec_amp.timeseries.keys())
+            all_ts_keys.update(rec_processed.timeseries.keys())
+            all_ts_keys.discard('amp')  # Remove amp from processed, use SNIRF version
+            prepared['timeseries_keys'] = ['amp'] + sorted([k for k in all_ts_keys if k != 'amp'])
+            
+            # Store processed rec for later access
+            prepared['processed_rec'] = rec_processed
+        else:
+            print(f"DEBUG: No processed data or no timeseries attribute, using only SNIRF timeseries")
+            prepared['timeseries_keys'] = list(rec_amp.timeseries.keys())
+            prepared['processed_rec'] = None
+        
+        prepared['aux_ts_keys'] = list(rec_amp.aux_ts.keys())
+        prepared['has_stim'] = len(rec_amp.stim) > 0
+
+        return prepared
+
+    def _get_recording(self, subj_key, run_key):
+        """
+        Retrieves a prepared recording, using a cache.
+        Now loads amp from SNIRF file and processed data from preprocessed SNIRF file.
+        """
+        cache_key = (subj_key, run_key)
+
+        if cache_key in self.cache:
+            self.cache.move_to_end(cache_key)
+            print(f"Cache hit for {subj_key} - {run_key}")
+            self.statbar.showMessage(f"📂 Loading preloaded data: {subj_key}/{run_key}", 2000)
+            QtWidgets.QApplication.processEvents()  # Force GUI update to show message
+            return self.cache[cache_key]
+
+        print(f"Cache miss for {subj_key} - {run_key}. Loading from disk.")
+        self.statbar.showMessage(f"💾 Loading data from disk: {subj_key}/{run_key}...", 0)  # 0 = permanent until changed
+        QtWidgets.QApplication.processEvents()  # Force GUI update to show message
+        
+        available_memory = psutil.virtual_memory().available
+        if available_memory < self.MEMORY_THRESHOLD:
+            if self.cache:
+                removed_key, _ = self.cache.popitem(last=False)
+                print(f"Low memory warning. Removed {removed_key} from cache.")
+
+        if len(self.cache) >= self.MAX_CACHE_SIZE:
+            removed_key, _ = self.cache.popitem(last=False)
+            print(f"Cache full. Removed {removed_key} from cache.")
+
+        file_info = self.file_map.get(subj_key, {}).get(run_key)
+        if not file_info:
+            print(f"Error: No file info found for {subj_key} - {run_key}")
+            return None
+        
+        snirf_path = file_info.get('snirf_path')
+        pkl_path = file_info.get('pkl_path')
+        
+        print(f"DEBUG: snirf_path = {snirf_path}")
+        print(f"DEBUG: pkl_path = {pkl_path}")
+        print(f"DEBUG: pkl_path exists = {pkl_path and os.path.exists(pkl_path)}")
+        
+        if not snirf_path:
+            print(f"Error: No SNIRF path for {subj_key} - {run_key}")
+            return None
+        
+        print(f"Loading from SNIRF: {snirf_path}")
+        
+        # Load amplitude data from SNIRF file
+        try:
+            import cedalion.io as io
+            rec_amp = io.read_snirf(snirf_path)[0]  # read_snirf returns a list, take first element
+            print(f"Loaded amplitude data from SNIRF")
+            
+            # Try to load events from TSV file and overwrite stim data
+            events_df = self._load_events_from_tsv(snirf_path)
+            if events_df is not None:
+                rec_amp.stim = events_df
+                print(f"Overwritten stim data with events from TSV file")
+            else:
+                print(f"Using stim data from SNIRF file")
+        except Exception as e:
+            print(f"Error loading SNIRF file: {e}")
+            return None
+        
+        # If preprocessed SNIRF file exists, load processed data
+        rec_processed = None
+        if pkl_path and os.path.exists(pkl_path):
+            print(f"Loading processed data from SNIRF: {pkl_path}")
+            try:
+                import cedalion.io as io
+                rec_processed_list = io.read_snirf(pkl_path)  # read_snirf returns a list
+                rec_processed = rec_processed_list[0] if rec_processed_list else None
+                print(f"Loaded processed data from SNIRF")
+                
+                # Try to load events from TSV file and overwrite stim data
+                if rec_processed is not None:
+                    events_df = self._load_events_from_tsv(snirf_path)  # Use raw snirf_path, not pkl_path
+                    if events_df is not None:
+                        rec_processed.stim = events_df
+                        print(f"Overwritten processed stim data with events from TSV file")
+            except Exception as e:
+                print(f"Error loading preprocessed SNIRF file: {e}")
+                rec_processed = None
+        else:
+            print(f"No processed data available for {subj_key} - {run_key}")
+        
+        # Prepare data using both sources
+        prepared_data = self._prepare_data_from_snirf_and_pkl(rec_amp, rec_processed)
+        
+        # Store file paths for later reference
+        prepared_data['snirf_path'] = snirf_path
+        prepared_data['pkl_path'] = pkl_path
+        prepared_data['has_processed_data'] = pkl_path is not None and os.path.exists(pkl_path)
+        
+        # Try to load corresponding HRF data (only if processed data exists)
+        hrf_data = None
+        if pkl_path:
+            try:
+                # Construct HRF file path
+                if '_preprocessed.snirf' in pkl_path:
+                    hrf_file_path = pkl_path.replace('preprocessed_data', 'hrf_estimate')
+                    
+                    # Remove '_run-<run-name>' pattern using regex
+                    import re
+                    hrf_file_path = re.sub(r'_run-[^_]+', '', hrf_file_path)
+                    
+                    hrf_file_path = hrf_file_path.replace('_preprocessed.snirf', '_hrf_estimate_conc.nc')
+                    
+                    if os.path.exists(hrf_file_path):
+                        print(f"Loading HRF data from: {hrf_file_path}")
+                        hrf_data = xr.open_dataset(hrf_file_path)
+                        print(f"HRF data loaded successfully")
+                    else:
+                        print(f"No HRF file found at: {hrf_file_path}")
+            except Exception as e:
+                print(f"Error loading HRF data: {e}")
+        
+        prepared_data['hrf_data'] = hrf_data
+        self.cache[cache_key] = prepared_data
+        self.statbar.showMessage(f"✓ Data loaded from disk: {subj_key}/{run_key}", 0)  # Keep until changed
+        QtWidgets.QApplication.processEvents()  # Force GUI update
+        
+        return prepared_data
+    
+    def _prepare_data_from_snirf_and_pkl(self, rec_amp, rec_processed):
+        """
+        Prepare data from SNIRF (amp) and preprocessed SNIRF (processed data).
+        Returns a dict with all necessary data for the GUI.
+        """
+        # Both rec_amp and rec_processed are Recording objects
+        # rec_amp has amplitude data, rec_processed has od/conc data
+        # Just pass both to _prepare_data which will merge them
+        return self._prepare_data(rec_amp, rec_processed)
+    
+    def _load_group_average_hrf(self):
+        """Load group average HRF data from groupaverage folder"""
+        print("=== _load_group_average_hrf called ===")
+        try:
+            # Get the current file path from the loaded recording data
+            current_subj = self.subj.currentText()
+            current_run = self.run.currentText()
+            print(f"Current subject: {current_subj}, run: {current_run}")
+            
+            # Get from cache if available
+            cache_key = (current_subj, current_run)
+            if cache_key in self.cache:
+                pkl_path = self.cache[cache_key].get('pkl_path')
+                print(f"Found pkl path in cache: {pkl_path}")
+            else:
+                # Fallback to file_map
+                file_info = self.file_map.get(current_subj, {}).get(current_run)
+                pkl_path = file_info.get('pkl_path') if file_info else None
+                print(f"PKL path from file_map: {pkl_path}")
+            
+            if not pkl_path:
+                print("No valid PKL file path found - returning None")
+                return None
+            
+            print(f"Using PKL file: {pkl_path}")
+            
+            # Construct group average HRF file path
+            # groupaverage folder is at the same level as hrf_estimate or preprocessed_data folder
+            import re
+            
+            # Get the base path (up to and including the working directory)
+            # Could be either: .../derivatives/cedalion/new_inclQ_first_walk or similar
+            if 'hrf_estimate' in pkl_path:
+                # Currently looking at HRF file, extract base path
+                base_path = pkl_path.split('hrf_estimate')[0]
+            elif 'preprocessed_data' in pkl_path:
+                # Currently looking at preprocessed file
+                base_path = pkl_path.split('preprocessed_data')[0]
+            else:
+                print("Could not determine base path - neither hrf_estimate nor preprocessed_data found")
+                return None
+            
+            print(f"Base path: {base_path}")
+            
+            # Get the task name from the current file
+            task_match = re.search(r'task-([^_/]+)', pkl_path)
+            task_name = task_match.group(1) if task_match else 'unknown'
+            print(f"Task name: {task_name}")
+            
+            # Try different naming patterns
+            groupavg_dir = os.path.join(base_path, 'group_results')
+            possible_patterns = [
+                f"task-{task_name}_nirs_groupaverage_chanspace_conc.nc",
+                f"task-{task_name}_hrf_estimate_conc.nc",
+                f"{task_name}_hrf_estimate_conc.nc"
+            ]
+            
+            for pattern in possible_patterns:
+                group_avg_path = os.path.join(groupavg_dir, pattern)
+                if os.path.exists(group_avg_path):
+                    print(f"Loading group average data from: {group_avg_path}")
+                    
+                    # Load netCDF file using xarray
+                    data = xr.open_dataset(group_avg_path)
+                    print(f"Loaded netCDF dataset with variables: {list(data.data_vars.keys())}")
+                    
+                    # Return the full xarray Dataset - it already contains all data variables
+                    # (hrf_est/group_average, total_stderr, tstat, mse_t, etc.)
+                    return data
+            
+            # If no file found, list what's available
+            print(f"No group average file found. Tried patterns: {possible_patterns}")
+            if os.path.exists(groupavg_dir):
+                files = os.listdir(groupavg_dir)
+                print(f"Available files in {groupavg_dir}:")
+                for f in files:
+                    print(f"  - {f}")
+            else:
+                print(f"Group average directory does not exist: {groupavg_dir}")
+            
+            return None
+        except Exception as e:
+            print(f"Error loading group average HRF: {e}")
+            import traceback
+            traceback.print_exc()
+            return None
+        
+    def _UI_SETUP(self):
+        # Set central widget
+        self._main = QtWidgets.QWidget()
+        self.setCentralWidget(self._main)
+
+        # Initialize layout
+        window_layout = QtWidgets.QVBoxLayout(self._main)
+        window_layout.setContentsMargins(10, 0, 10, 10)
+        window_layout.setSpacing(10)
+
+        # Set Minimum Size
+        self.setMinimumSize(1000, 850)
+
+        # Set Window Title
+        self.setWindowTitle("Time Series")
+
+        # Create Status Bar
+        self.statbar = self.statusBar()
+        self.statbar.setStyleSheet("QStatusBar { background-color: #f0f0f0; padding: 5px; font-size: 11pt; }")
+        self.statbar.showMessage("Ready to Load SNIRF File!")
+
+        # Filler plot for now
+        self.plots = FigureCanvas(Figure(figsize=(30, 8)))
+        self.plots.setFocusPolicy(QtCore.Qt.ClickFocus)
+        self.plots.setFocus()
+
+        (self._dataTimeSeries_ax, self._optode_ax) = self.plots.figure.subplots(
+            1, 2, width_ratios=[2, 1]
+        )
+        self._auxTimeSeries_ax = self._dataTimeSeries_ax.twinx()
+        self.plots.figure.tight_layout()
+        self._optode_ax.axis('off')
+        self._dataTimeSeries_ax.grid("True",axis="y")
+        # Get the current position
+        pos = self._dataTimeSeries_ax.get_position()
+        # Adjust the left position
+        new_pos = [pos.x0 + 0.075, pos.y0, pos.width - 0.075, pos.height]
+        # Set the new position
+        self._dataTimeSeries_ax.set_position(new_pos)
+        self._dataTimeSeries_ax.clear()
+
+        window_layout.addWidget(NavigationToolbar(self.plots,self),stretch=1)
+        window_layout.addWidget(self.plots, stretch=8)
+
+        # Connect Plots
+        self.shift_pressed = False
+        self.plots.mpl_connect("key_press_event", self._shift_is_pressed)
+        self.plots.mpl_connect("key_release_event", self._shift_is_released)
+        self.plots.mpl_connect("pick_event", self._optode_picked)
+
+        # Create Control Panel
+        control_panel = QtWidgets.QGroupBox("Control Panel")
+        control_panel_layout = QtWidgets.QHBoxLayout()
+        control_panel_layout.setSpacing(20)
+        control_panel.setLayout(control_panel_layout)
+        window_layout.addWidget(control_panel, stretch=1)
+        
+        # Create File Control Layout
+        file_layout = QtWidgets.QGridLayout()
+        file_layout.setAlignment(QtCore.Qt.AlignTop)
+        control_panel_layout.addLayout(
+            file_layout,
+        )
+        
+        ## Subject Selector
+        self.subj = QtWidgets.QComboBox()
+        if self.oftype == "rec":
+            self.subj.addItems(["None"])
+        else:
+            self.subj.addItems(self.subjects)
+        self.subj.setCurrentIndex(0)
+        self.subj.setFixedWidth(200)
+        self.subj.currentTextChanged.connect(self._subj_changed)
+        file_layout.addWidget(QtWidgets.QLabel("Subject:"), 0, 0)
+        file_layout.addWidget(self.subj, 0, 1)
+        
+        ## Run Selector
+        self.run = QtWidgets.QComboBox()
+        self._update_run_box() # Populate runs for the initial subject
+        self.run.setFixedWidth(200)
+        self.run.currentTextChanged.connect(self._run_changed)
+        file_layout.addWidget(QtWidgets.QLabel("Run:"), 1, 0)
+        file_layout.addWidget(self.run, 1, 1)
+
+        # Create Timeseries Controls Layout
+        ts_layout = QtWidgets.QGridLayout()
+        ts_layout.setAlignment(QtCore.Qt.AlignTop)
+        control_panel_layout.addLayout(
+            ts_layout,
+        )
+
+        ## Create Timeseries Controls
+        self.ts = QtWidgets.QListWidget()
+        self.ts.addItems(["None"])
+        self.ts.setCurrentRow(0)
+        self.ts.setFixedHeight(90)
+        self.ts.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.ts.currentTextChanged.connect(self._ts_changed)
+        ts_layout.addWidget(QtWidgets.QLabel("Timeseries:"), 0, 0)
+        ts_layout.addWidget(self.ts, 0, 1)
+        
+        ## Create HRF View Checkbox and chromophore selectors
+        hrf_widget = QtWidgets.QWidget()
+        hrf_main_layout = QtWidgets.QVBoxLayout()  # Changed to vertical layout
+        hrf_main_layout.setContentsMargins(0, 0, 0, 0)
+        hrf_main_layout.setSpacing(5)
+        
+        # First row: checkboxes
+        hrf_checkbox_layout = QtWidgets.QHBoxLayout()
+        hrf_checkbox_layout.setSpacing(10)
+        
+        self.hrf_view = QtWidgets.QCheckBox("View HRF")
+        self.hrf_view.stateChanged.connect(self._toggle_hrf_view)
+        self.hrf_view.setEnabled(False)  # Will be enabled when HRF data is available
+        hrf_checkbox_layout.addWidget(self.hrf_view)
+        
+        # Add HbO checkbox
+        self.hrf_hbo = QtWidgets.QCheckBox("HbO")
+        self.hrf_hbo.setChecked(True)  # Default to HbO selected
+        self.hrf_hbo.stateChanged.connect(self._hrf_chromo_changed)
+        self.hrf_hbo.setEnabled(False)  # Will be enabled when HRF view is active
+        hrf_checkbox_layout.addWidget(self.hrf_hbo)
+        
+        # Add HbR checkbox
+        self.hrf_hbr = QtWidgets.QCheckBox("HbR")
+        self.hrf_hbr.setChecked(False)  # Default to HbR not selected
+        self.hrf_hbr.stateChanged.connect(self._hrf_chromo_changed)
+        self.hrf_hbr.setEnabled(False)  # Will be enabled when HRF view is active
+        hrf_checkbox_layout.addWidget(self.hrf_hbr)
+        
+        # Add separator
+        separator = QtWidgets.QFrame()
+        separator.setFrameShape(QtWidgets.QFrame.VLine)
+        separator.setFrameShadow(QtWidgets.QFrame.Sunken)
+        hrf_checkbox_layout.addWidget(separator)
+        
+        # Add Group Average checkbox (enabled all the time)
+        self.hrf_group_avg = QtWidgets.QCheckBox("Group Average")
+        self.hrf_group_avg.setChecked(False)
+        self.hrf_group_avg.stateChanged.connect(self._hrf_group_avg_changed)
+        self.hrf_group_avg.setEnabled(True)  # Always enabled
+        hrf_checkbox_layout.addWidget(self.hrf_group_avg)
+        hrf_checkbox_layout.addStretch()
+        
+        hrf_main_layout.addLayout(hrf_checkbox_layout)
+        
+        # Second row: buttons arranged horizontally
+        hrf_button_layout = QtWidgets.QHBoxLayout()
+        hrf_button_layout.setSpacing(10)
+        
+        # Add Launch Plot Probe button
+        self.launch_plot_probe_btn = QtWidgets.QPushButton("Launch Plot Probe")
+        self.launch_plot_probe_btn.clicked.connect(self._launch_plot_probe)
+        self.launch_plot_probe_btn.setEnabled(False)  # Will be enabled when HRF view is active
+        self.launch_plot_probe_btn.setMinimumWidth(150)  # Make button wider to show full text
+        hrf_button_layout.addWidget(self.launch_plot_probe_btn)
+        
+        # Add Image Recon button (independent of HRF view)
+        self.image_recon_btn = QtWidgets.QPushButton("Image Reconstruction")
+        self.image_recon_btn.clicked.connect(self._launch_image_recon)
+        self.image_recon_btn.setEnabled(False)  # Will be enabled when data is loaded
+        self.image_recon_btn.setMinimumWidth(150)  # Make button wider to show full text
+        hrf_button_layout.addWidget(self.image_recon_btn)
+        
+        hrf_button_layout.addStretch()
+        hrf_main_layout.addLayout(hrf_button_layout)
+        
+        hrf_widget.setLayout(hrf_main_layout)
+        ts_layout.addWidget(hrf_widget, 1, 1)
+
+        # Create Aux/wv selector Layout
+        aux_layout = QtWidgets.QGridLayout()
+        aux_layout.setAlignment(QtCore.Qt.AlignTop)
+        control_panel_layout.addLayout(aux_layout)
+
+        ## Aux Selector
+        self.auxs = QtWidgets.QComboBox()
+        self.auxs.addItems(["None"])
+        self.auxs.setCurrentIndex(0)
+        self.auxs.currentTextChanged.connect(self._aux_changed)
+        aux_layout.addWidget(QtWidgets.QLabel("Aux:"), 0, 0)
+        aux_layout.addWidget(self.auxs, 0, 1)
+
+        ## Create Wavelength / Concentration Controls
+        self.wv = QtWidgets.QListWidget()
+        self.wv.setFixedHeight(45)
+        self.wv.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.wv.itemSelectionChanged.connect(self._wv_changed)
+        self.wv_label = QtWidgets.QLabel("Wavelength/Concentration:")
+        aux_layout.addWidget(self.wv_label, 1, 0)
+        aux_layout.addWidget(self.wv, 1, 1)
+
+        # Create Optional Controls Layout
+        opt_layout = QtWidgets.QVBoxLayout()
+        opt_layout.setAlignment(QtCore.Qt.AlignTop)
+        control_panel_layout.addLayout(
+            opt_layout,
+        )
+
+        ## Create Opt2Circ Button
+        self.opt2circ = QtWidgets.QCheckBox("View optodes as circles")
+        self.opt2circ.stateChanged.connect(self._toggle_circles)
+        opt_layout.addWidget(self.opt2circ)
+
+        ## Create Stimulus Selection Dropdown with checkboxes
+        stim_label = QtWidgets.QLabel("Stimuli:")
+        opt_layout.addWidget(stim_label)
+        
+        # Create a button that opens stimulus selection dialog
+        self.stim_button = QtWidgets.QPushButton("Select Stimuli")
+        self.stim_button.clicked.connect(self._open_stim_dialog)
+        opt_layout.addWidget(self.stim_button)
+        
+        # Track selected stimuli and available stimulus types
+        self.selected_stim_types = set()
+        self.available_stim_types = []
+        self.hrf_available_stim_types = []  # Track which stim types have HRF data
+
+        ## Spacer
+        control_panel_layout.addStretch()
+
+        # Create button action for opening file
+        open_btn = QAction("Open...", self)
+        open_btn.setStatusTip("Open SNIRF file")
+        open_btn.triggered.connect(self._open_dialog)
+
+        ## Create menu
+        # Use self.menuBar() for proper cross-platform menu bar support
+        # On macOS this integrates with the native menu bar
+        menu = self.menuBar()
+
+        ## Populate menu
+
+        file_menu = menu.addMenu("&File")
+        file_menu.addAction(open_btn)
+        
+        # Create Snakemake menu with Setup first, then config items, then Run
+        self.snakemake_menu = menu.addMenu("&Snakemake")
+        
+        setup_action = QAction("Setup Pipeline...", self)
+        setup_action.setStatusTip("Select Snakefile and load configuration")
+        setup_action.setMenuRole(QAction.MenuRole.NoRole)  # Prevent macOS from moving this to app menu
+        setup_action.triggered.connect(self._snakemake_setup_pipeline)
+        self.snakemake_menu.addAction(setup_action)
+        
+        self.snakemake_menu.addSeparator()
+        
+        dataset_action = QAction("Dataset", self)
+        dataset_action.setStatusTip("Dataset configuration")
+        dataset_action.triggered.connect(self._snakemake_dataset)
+        self.snakemake_menu.addAction(dataset_action)
+        
+        # Dynamic config items will be inserted here after setup
+        
+        self.snakemake_menu.addSeparator()
+        
+        run_pipeline_action = QAction("Run Pipeline...", self)
+        run_pipeline_action.setStatusTip("Run Snakemake pipeline")
+        run_pipeline_action.triggered.connect(self._snakemake_run_pipeline)
+        self.snakemake_menu.addAction(run_pipeline_action)
+
+        # In case there is snirfRec
+        if self.snirfRec is not None:
+            self._init_widgets()
+
+    def _open_dialog(self):
+        # Grab the appropriate SNIRF file
+        self._fname = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Open File",
+            "${HOME}",
+            "SNIRF Files (*.snirf)",
+        )[0]
+        self.statbar.showMessage("Loading SNIRF File...")
+        t0 = time.time()
+        cread = cedalion.io.read_snirf(self._fname)
+        self.snirfRec = cread[0]
+        
+        # Try to load events from TSV file and overwrite stim data
+        events_df = self._load_events_from_tsv(self._fname)
+        if events_df is not None:
+            self.snirfRec.stim = events_df
+            print(f"Overwritten stim data with events from TSV file")
+        else:
+            print(f"Using stim data from SNIRF file")
+        
+        t1 = time.time()
+        self.statbar.showMessage(f"File Loaded in {t1 - t0:.2f} seconds!")
+        self.auxs.setCurrentIndex(0)
+        self.ts.setCurrentRow(0)
+        self.aux_window.setText("0")
+        self.selected_stim_types = set()  # Clear stimulus selection
+        self._init_widgets()
+
+    def _get_data_directory(self):
+        """Extract the data directory from file_map paths"""
+        print("\n" + "="*60)
+        print("DEBUG: _get_data_directory() called")
+        print(f"DEBUG: file_map type: {type(self.file_map)}")
+        print(f"DEBUG: file_map empty: {not self.file_map}")
+        
+        # Try to get a file path from file_map
+        if not self.file_map:
+            print("DEBUG: file_map is empty, returning cwd")
+            return os.getcwd()
+        
+        print(f"DEBUG: file_map has {len(self.file_map)} subjects")
+        for subj, subj_dict in self.file_map.items():
+            print(f"DEBUG: Checking subject: {subj}")
+            print(f"DEBUG: Runs: {list(subj_dict.keys())}")
+            for run, file_info in subj_dict.items():
+                print(f"DEBUG: Run {run}, file_info: {file_info}")
+                # Extract pkl_path from the dict
+                file_path = file_info.get('pkl_path') if isinstance(file_info, dict) else None
+                if file_path:
+                    print(f"DEBUG: Found file path: {file_path}")
+                    # Extract the base path up to and including the main data directory
+                    # Path structure: .../data_dir/derivatives/cedalion/...
+                    # We want to get to the data_dir level
+                    if 'derivatives' in file_path:
+                        parts = file_path.split('derivatives')
+                        print(f"DEBUG: Split on 'derivatives': {parts}")
+                        # The first part contains the data directory path
+                        data_dir = parts[0].rstrip(os.sep).rstrip('/')
+                        print(f"DEBUG: Extracted data directory: {data_dir}")
+                        print("="*60 + "\n")
+                        return data_dir
+        # Fallback to current directory if no paths found
+        print(f"DEBUG: No valid paths found in file_map, using cwd: {os.getcwd()}")
+        print("="*60 + "\n")
+        return os.getcwd()
+    
+    def _detect_derivatives_subfolder(self):
+        """Detect derivatives_subfolder from file_map paths"""
+        # Try to extract derivatives subfolder from file paths
+        if not self.file_map:
+            return ""
+        
+        for subj, subj_dict in self.file_map.items():
+            for run, file_info in subj_dict.items():
+                # Extract pkl_path from the dict
+                file_path = file_info.get('pkl_path') if isinstance(file_info, dict) else None
+                if file_path and 'derivatives' in file_path:
+                    # Extract the path between 'derivatives/' and the subject folder
+                    parts = file_path.split('derivatives')
+                    if len(parts) > 1:
+                        # Get everything after derivatives/
+                        after_derivatives = parts[1].lstrip(os.sep).lstrip('/')
+                        # Split by path separator to get folder structure
+                        path_parts = after_derivatives.split(os.sep)
+                        # Keep folders until we hit preprocessed_data, hrf_estimate, or sub- folders
+                        # These indicate we're at the pipeline output level or subject level
+                        pipeline_folders = ['preprocessed_data', 'hrf_estimate', 'image_results', 
+                                          'group_results', 'qa_reports']
+                        subfolder_parts = []
+                        for part in path_parts:
+                            # Stop at subject folders or pipeline output folders
+                            if part.startswith('sub-') or part in pipeline_folders or not part:
+                                break
+                            subfolder_parts.append(part)
+                        
+                        if subfolder_parts:
+                            derivatives_subfolder = os.path.join(*subfolder_parts)
+                            print(f"Detected derivatives_subfolder: {derivatives_subfolder}")
+                            return derivatives_subfolder
+        
+        print("Could not detect derivatives_subfolder, using empty string")
+        return ""
+    
+    def _snakemake_dataset(self):
+        """Handle Dataset menu action"""
+        if not self.snakemake_config_path:
+            # Show minimal dialog with only root_dir and derivatives_subfolder
+            data_dir = self._get_data_directory()
+            
+            # Try to find config ONLY in the selected path_to_data folder
+            config_path = None
+            if self.path_to_data and os.path.exists(self.path_to_data):
+                # Check directly in the selected folder only
+                test_path = os.path.join(self.path_to_data, 'snakemake_config.yaml')
+                if os.path.exists(test_path):
+                    config_path = test_path
+                    print(f"Found config in selected folder: {config_path}")
+                else:
+                    # Config doesn't exist in selected folder, use path as default location
+                    config_path = test_path
+                    print(f"Config not found, will create at: {config_path}")
+            else:
+                # Fallback if path_to_data not set
+                config_path = os.path.join(data_dir, 'derivatives', 'snakemake_config.yaml')
+            
+            # Only show root_dir and derivatives_subfolder if no config loaded
+            if not self.snakemake_config:
+                self._edit_config_minimal_dataset(config_path)
+            else:
+                self._edit_config_block(config_path, 'dataset', readonly_keys=['root_dir', 'derivatives_subfolder'])
+        else:
+            self._edit_config_block(self.snakemake_config_path, 'dataset', readonly_keys=['root_dir', 'derivatives_subfolder'])
+        
+    def _snakemake_config_item(self, block_name):
+        """Handle dynamic config menu action"""
+        if self.snakemake_config_path:
+            self._edit_config_block(self.snakemake_config_path, block_name)
+        else:
+            QtWidgets.QMessageBox.information(
+                self,
+                "No Config Loaded",
+                "Please use 'Setup Pipeline...' first to select a Snakefile and load the config."
+            )
+    
+    def _snakemake_setup_pipeline(self):
+        """Handle Setup Pipeline menu action - select Snakefile and load config"""
+        dialog = SnakemakeSetupDialog(self, self.snakefile_path, self.snakemake_config_path)
+        
+        if dialog.exec():
+            snakefile_path = dialog.snakefile_path
+            config_path = dialog.config_path
+            
+            # Auto-detect root_dir and derivatives_subfolder from current data
+            data_dir = self._get_data_directory()
+            derivatives_subfolder = self._detect_derivatives_subfolder()
+            
+            # If detected subfolder is exactly "cedalion", set to empty since Snakefile adds it
+            if derivatives_subfolder == 'cedalion':
+                print(f"Auto-detected derivatives_subfolder is 'cedalion', setting to empty (Snakefile adds it)")
+                derivatives_subfolder = ''
+            
+            print(f"Auto-detected root_dir: {data_dir}")
+            print(f"Auto-detected derivatives_subfolder: {derivatives_subfolder}")
+            
+            # Load the source config
+            with open(config_path, 'r') as f:
+                temp_config = yaml.safe_load(f)
+            
+            # Use path_to_data directly as the target directory (user selected folder)
+            if self.path_to_data and os.path.exists(self.path_to_data):
+                target_dir = self.path_to_data
+                print(f"Using selected path_to_data as target: {target_dir}")
+            elif derivatives_subfolder:
+                target_dir = os.path.join(data_dir, 'derivatives', derivatives_subfolder)
+                print(f"Using detected derivatives_subfolder: {target_dir}")
+            else:
+                target_dir = os.path.join(data_dir, 'derivatives')
+                print(f"Using default derivatives folder: {target_dir}")
+            
+            print(f"Target directory: {target_dir}")
+            os.makedirs(target_dir, exist_ok=True)
+            print(f"Created target directory (if it didn't exist)")
+            
+            # Target config path in target directory
+            target_config_path = os.path.join(target_dir, 'snakemake_config.yaml')
+            
+            print(f"Source config path: {config_path}")
+            print(f"Target config path: {target_config_path}")
+            print(f"Paths are same: {os.path.abspath(config_path) == os.path.abspath(target_config_path)}")
+            
+            # Copy config file and update root_dir/derivatives_subfolder while preserving format
+            if os.path.abspath(config_path) != os.path.abspath(target_config_path):
+                try:
+                    # Extract derivatives_subfolder from path_to_data
+                    # e.g., path_to_data = "C:/data/derivatives/cedalion/new_inclQ_first_walk"
+                    # derivatives_subfolder should be "new_inclQ_first_walk" (NOT "cedalion/new_inclQ_first_walk")
+                    # because Snakefile adds "cedalion/" automatically
+                    if self.path_to_data and 'derivatives' in self.path_to_data:
+                        parts = self.path_to_data.split('derivatives')
+                        if len(parts) > 1:
+                            derivatives_subfolder = parts[1].lstrip(os.sep).lstrip('/')
+                            # Remove 'cedalion' prefix since Snakefile adds it automatically
+                            # Handle both "cedalion/..." and exactly "cedalion"
+                            if derivatives_subfolder == 'cedalion':
+                                derivatives_subfolder = ''  # Working directly in cedalion folder
+                            elif derivatives_subfolder.startswith('cedalion/') or derivatives_subfolder.startswith('cedalion\\'):
+                                derivatives_subfolder = derivatives_subfolder.split('cedalion', 1)[1].lstrip(os.sep).lstrip('/')
+                            print(f"Extracted derivatives_subfolder from path_to_data: {derivatives_subfolder}")
+                    
+                    # Read original file as text to preserve formatting
+                    with open(config_path, 'r', encoding='utf-8') as f:
+                        config_text = f.read()
+                    
+                    # Convert paths to use forward slashes (works on Windows and avoids YAML escape issues)
+                    data_dir_normalized = data_dir.replace('\\', '/')
+                    derivatives_subfolder_normalized = derivatives_subfolder.replace('\\', '/') if derivatives_subfolder else ''
+                    
+                    # Replace root_dir value using regex (preserves comments and formatting)
+                    config_text = re.sub(
+                        r'(root_dir:\s*)(["\']?).*?\2(\s*(?:#.*)?$)',
+                        rf'\1\2{data_dir_normalized}\2\3',
+                        config_text,
+                        flags=re.MULTILINE
+                    )
+                    
+                    # Replace derivatives_subfolder value using regex
+                    config_text = re.sub(
+                        r'(derivatives_subfolder:\s*)(["\']?).*?\2(\s*(?:#.*)?$)',
+                        rf'\1\2{derivatives_subfolder_normalized}\2\3',
+                        config_text,
+                        flags=re.MULTILINE
+                    )
+                    
+                    # Write to target location
+                    with open(target_config_path, 'w', encoding='utf-8') as f:
+                        f.write(config_text)
+                    
+                    print(f"Copied config from {config_path} to {target_config_path}")
+                    print(f"Updated config with root_dir={data_dir} and derivatives_subfolder={derivatives_subfolder}")
+                    
+                except Exception as e:
+                    QtWidgets.QMessageBox.warning(
+                        self,
+                        "Config Copy Failed",
+                        f"Could not copy config to derivatives folder:\n{str(e)}\n\nUsing original location."
+                    )
+                    target_config_path = config_path
+            
+            # Save homer.config with Snakefile path in the same directory
+            self._save_homer_config(snakefile_path, target_config_path, target_dir)
+            
+            # Load config and update menu
+            self._load_snakemake_config(snakefile_path, target_config_path)
+    
+    def _snakemake_run_pipeline(self):
+        """Handle Run Pipeline menu action"""
+        # Check if setup has been done
+        if not self.snakefile_path or not self.snakemake_config_path:
+            reply = QtWidgets.QMessageBox.question(
+                self,
+                "Setup Required",
+                "Pipeline has not been set up yet. Would you like to set it up now?",
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+            )
+            if reply == QtWidgets.QMessageBox.Yes:
+                self._snakemake_setup_pipeline()
+                if not self.snakefile_path:  # User cancelled setup
+                    return
+            else:
+                return
+        
+        # Get current subject and run selection
+        current_subject = self.subj.currentText() if self.subj.currentText() != "None" else None
+        current_run = self.run.currentText() if self.run.currentText() and self.run.currentText() != "" else None
+        
+        dialog = SnakemakeRunDialog(self, current_subject, current_run)
+        if dialog.exec():
+            dry_run = dialog.dry_run_checkbox.isChecked()
+            show_summary = dialog.summary_checkbox.isChecked()
+            cores_text = dialog.cores_combo.currentText()
+            run_current_only = dialog.current_selection_checkbox.isChecked()
+            conda_env = dialog.env_combo.currentText()
+            # Store conda environment for future summary commands
+            self.conda_env = conda_env
+            
+            # Use the already-loaded snakefile and config
+            snakefile_path = self.snakefile_path
+            config_path = self.snakemake_config_path
+            original_config_path = self.snakemake_config_path  # Keep original for summary
+            
+            # Build the snakemake command
+            cmd = ['snakemake', '-s', snakefile_path]
+            
+            # Handle config overrides for current selection if enabled
+            if run_current_only and current_subject and current_run:
+                # Parse subject and run from the selection
+                # Format: "sub-01" or "sub-01_ses-01", "task-IWHD_run_run-01"
+                # Use non-greedy matching to handle task names with underscores
+                subject_match = re.search(r'sub-(\w+)', current_subject)
+                # Match task name up until _run- (non-greedy)
+                task_match = re.search(r'task-(.+?)(?:_run-|$)', current_run) if current_run else None
+                # Match run number after run-
+                run_match = re.search(r'run-(\w+)', current_run) if current_run else None
+                
+                # Store current selection for color logic
+                self.run_current_only_mode = True
+                self.current_selection_subject = subject_match.group(1) if subject_match else None
+                self.current_selection_task = task_match.group(1) if task_match else None
+                self.current_selection_run = run_match.group(1) if run_match else None
+                
+                print(f"DEBUG: Run on current selection only mode enabled")
+                print(f"  Selected: sub-{self.current_selection_subject}, task-{self.current_selection_task}, run-{self.current_selection_run}")
+                
+                # Create a temporary config file with overrides using text-based approach
+                # This preserves all config sections, comments, and formatting
+                if config_path and os.path.exists(config_path):
+                    try:
+                        # Read original config as text to preserve formatting
+                        with open(config_path, 'r', encoding='utf-8') as f:
+                            config_text = f.read()
+                        
+                        print(f"DEBUG: Creating temp config from: {config_path}")
+                        
+                        # Replace subject value using regex (handles both inline and block formats)
+                        if subject_match:
+                            subject_id = subject_match.group(1)
+                            # Try inline format first: subject: [item1, item2]
+                            if re.search(r'subject:\s*\[', config_text):
+                                config_text = re.sub(
+                                    r'(subject:\s*\[)[^\]]*(\])',
+                                    rf'\g<1>"{subject_id}"\g<2>',
+                                    config_text
+                                )
+                                print(f"DEBUG: Replaced subject with [\"{subject_id}\"] (inline format)")
+                            # Try block format: subject:\n  - item1
+                            elif re.search(r'subject:\s*\n', config_text):
+                                config_text = re.sub(
+                                    r'(subject:)\s*\n(\s*-\s*[^\n]+\n)*',
+                                    rf'\g<1>\n  - "{subject_id}"\n',
+                                    config_text
+                                )
+                                print(f"DEBUG: Replaced subject with - \"{subject_id}\" (block format)")
+                        
+                        # Replace task value using regex
+                        if task_match:
+                            task_id = task_match.group(1)
+                            # Try inline format first
+                            if re.search(r'task:\s*\[', config_text):
+                                config_text = re.sub(
+                                    r'(task:\s*\[)[^\]]*(\])',
+                                    rf'\g<1>"{task_id}"\g<2>',
+                                    config_text
+                                )
+                                print(f"DEBUG: Replaced task with [\"{task_id}\"] (inline format)")
+                            # Try block format
+                            elif re.search(r'task:\s*\n', config_text):
+                                config_text = re.sub(
+                                    r'(task:)\s*\n(\s*-\s*[^\n]+\n)*',
+                                    rf'\g<1>\n  - "{task_id}"\n',
+                                    config_text
+                                )
+                                print(f"DEBUG: Replaced task with - \"{task_id}\" (block format)")
+                        
+                        # Replace run value using regex
+                        if run_match:
+                            run_id = run_match.group(1)
+                            # Try inline format first
+                            if re.search(r'run:\s*\[', config_text):
+                                config_text = re.sub(
+                                    r'(run:\s*\[)[^\]]*(\])',
+                                    rf'\g<1>"{run_id}"\g<2>',
+                                    config_text
+                                )
+                                print(f"DEBUG: Replaced run with [\"{run_id}\"] (inline format)")
+                            # Try block format
+                            elif re.search(r'run:\s*\n', config_text):
+                                config_text = re.sub(
+                                    r'(run:)\s*\n(\s*-\s*[^\n]+\n)*',
+                                    rf'\g<1>\n  - "{run_id}"\n',
+                                    config_text
+                                )
+                                print(f"DEBUG: Replaced run with - \"{run_id}\" (block format)")
+                        
+                        # Set num_runs to 1 since we're running single run only
+                        config_text = re.sub(
+                            r'(num_runs:\s*)\d+',
+                            r'\g<1>1',
+                            config_text
+                        )
+                        print(f"DEBUG: Set num_runs to 1 for current selection only mode")
+                        
+                        # Set subjects_to_exclude to all subjects except the current one
+                        if subject_match:
+                            subject_id = subject_match.group(1)
+                            try:
+                                # Load config to get root_dir
+                                import yaml
+                                with open(config_path, 'r', encoding='utf-8') as f:
+                                    config_data = yaml.safe_load(f)
+                                root_dir = config_data.get('dataset', {}).get('root_dir', '')
+                                
+                                # Find all sub-* directories in root_dir
+                                if root_dir and os.path.exists(root_dir):
+                                    all_subjects = []
+                                    for item in os.listdir(root_dir):
+                                        if item.startswith('sub-') and os.path.isdir(os.path.join(root_dir, item)):
+                                            # Extract subject ID (without "sub-" prefix)
+                                            sub_id = item.replace('sub-', '')
+                                            all_subjects.append(sub_id)
+                                    
+                                    # Exclude all subjects except current one
+                                    subjects_to_exclude = [s for s in all_subjects if s != subject_id]
+                                    if subjects_to_exclude:
+                                        # Replace subjects_to_exclude in config
+                                        exclude_str = ', '.join([f'"{s}"' for s in subjects_to_exclude])
+                                        config_text = re.sub(
+                                            r'(subjects_to_exclude:\s*)\[[^\]]*\]',
+                                            rf'\g<1>[{exclude_str}]',
+                                            config_text
+                                        )
+                                        print(f"DEBUG: Set subjects_to_exclude to exclude all except {subject_id}: {subjects_to_exclude}")
+                            except Exception as e:
+                                print(f"WARNING: Could not update subjects_to_exclude: {e}")
+                        
+                        # Write temporary config file (for snakemake execution ONLY)
+                        # Save in same directory as original config instead of temp folder
+                        config_dir = os.path.dirname(config_path)
+                        temp_config_path = os.path.join(config_dir, 'snakemake_config_temp.yaml')
+                        with open(temp_config_path, 'w', encoding='utf-8') as f:
+                            f.write(config_text)
+                        
+                        # Store original config path for monitoring (before overwriting)
+                        original_config_path = config_path
+                        # Store as instance variable so monitoring can access it
+                        self.snakemake_config_path_original = original_config_path
+                        config_path = temp_config_path  # Use temp config for execution
+                        print(f"DEBUG: Created temp config at: {config_path}")
+                        print(f"DEBUG: Original config preserved for monitoring: {original_config_path}")
+                        
+                    except Exception as e:
+                        print(f"ERROR: Config override failed: {e}")
+                        import traceback
+                        traceback.print_exc()
+                        QtWidgets.QMessageBox.warning(
+                            self,
+                            "Config Override Failed",
+                            f"Could not create temporary config with overrides:\n{str(e)}\n\nProceeding without current selection filter."
+                        )
+                        self.run_current_only_mode = False
+            else:
+                # Not in current selection mode
+                self.run_current_only_mode = False
+                self.current_selection_subject = None
+                self.current_selection_task = None
+                self.current_selection_run = None
+            
+            if config_path:
+                cmd.extend(['--configfile', config_path])
+            
+            if dry_run:
+                cmd.append('-n')
+            
+            if show_summary:
+                cmd.append('--summary')
+            
+            if dialog.unlock_checkbox.isChecked():
+                cmd.append('--unlock')
+            
+            if dialog.rerun_incomplete_checkbox.isChecked():
+                cmd.append('--rerun-incomplete')
+            
+            cmd.extend(['-p', '--cores', cores_text])
+            
+            # Add target rule (default is all_default, which runs if not specified)
+            target_rule = dialog.target_combo.currentData() or dialog.target_combo.currentText()
+            if target_rule and target_rule != 'all_default':
+                cmd.append(target_rule)
+            
+            # Show the command that will be run
+            cmd_str = ' '.join(cmd)
+            reply = QtWidgets.QMessageBox.question(
+                self,
+                "Confirm Pipeline Run",
+                f"Run this command?\n\n{cmd_str}\n\nThis will run in a terminal window.",
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+            )
+            
+            if reply == QtWidgets.QMessageBox.Yes:
+                try:
+                    # First, unlock the directory in case of stale locks
+                    print("Unlocking workflow directory...")
+                    unlock_cmd = ['conda', 'run', '-n', conda_env, '--no-capture-output',
+                                  'snakemake', '-s', snakefile_path, '--configfile', config_path, '--unlock']
+                    unlock_result = subprocess.run(unlock_cmd, capture_output=True, text=True, timeout=30)
+                    if unlock_result.returncode == 0:
+                        print("Workflow directory unlocked successfully")
+                    else:
+                        print(f"WARNING: Unlock command returned code {unlock_result.returncode}")
+                        print(f"STDERR: {unlock_result.stderr[:200]}")
+                    
+                    # Now run summary to get status of all workflow files
+                    # When running "current selection only", use temp config for summary too
+                    # so it only detects files for the current selection
+                    summary_config = config_path  # Use same config as execution (temp if current selection only)
+                    config_type = "temp (current selection)" if run_current_only else "full"
+                    print(f"Running summary for {config_type} config scope...")
+                    file_status_map = self._run_snakemake_summary(snakefile_path, summary_config, target_rule)
+                    
+                    if file_status_map:
+                        print(f"Summary found {len(file_status_map)} workflow files in current scope")
+                        # Store in current_scope_files for simplified color system
+                        self.current_scope_files = file_status_map
+                        self.file_status_map = file_status_map  # Backward compatibility
+                        self.all_scope_files = {}  # No dual summary system
+                        
+                        # Extract files that need processing
+                        self.expected_pipeline_outputs = {
+                            path for path, info in file_status_map.items()
+                            if info['plan'] not in ['no', 'update']  # 'update pending' or 'create'
+                        }
+                        print(f"Files needing processing: {len(self.expected_pipeline_outputs)}")
+                    else:
+                        print("WARNING: No workflow files detected from summary")
+                        QtWidgets.QMessageBox.warning(
+                            self,
+                            "Summary Warning",
+                            "Summary did not detect any workflow files.\n\n"
+                            "This may indicate:\n"
+                            "- Pipeline configuration issues\n"
+                            "- Summary parsing failure\n\n"
+                            "Do you want to continue anyway?",
+                            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+                        )
+                        if QtWidgets.QMessageBox.No:
+                            return
+                        self.current_scope_files = {}
+                        self.file_status_map = {}
+                        self.all_scope_files = {}
+                        self.expected_pipeline_outputs = set()
+                    
+                    # Save pipeline status and update colors only for actual runs (not dry runs or summaries)
+                    if not dry_run and not show_summary:
+                        # Save pipeline status before starting
+                        self._save_pipeline_status_on_start()
+                        
+                        # Immediately update all colors to reflect new pipeline state
+                        # Files in config will turn orange, files not in config stay/turn red
+                        self._update_all_file_colors()
+                    
+                    # Run in a new console window on Windows
+                    if sys.platform == 'win32':
+                        # Launch in new terminal and capture the process
+                        # We need to start cmd with the command, and get the child snakemake process
+                        cmd_str = ' '.join(f'"{part}"' if ' ' in part else part for part in cmd)
+                        
+                        # TEMPORARY: Keep terminal open for ALL runs to debug issues
+                        terminal_flag = '/k'  # Keep terminal open
+                        # if dry_run or show_summary:
+                        #     terminal_flag = '/k'  # Keep terminal open
+                        # else:
+                        #     terminal_flag = '/c'  # Close terminal when done
+                        
+                        full_cmd = f'start "Snakemake Pipeline" cmd {terminal_flag} "conda activate {conda_env} && {cmd_str}"'
+                        subprocess.Popen(full_cmd, shell=True)
+                        
+                        # Only monitor actual pipeline runs, not dry runs or summaries
+                        if not dry_run and not show_summary:
+                            # Store the actual config path used (temp or original) for process detection
+                            self._actual_config_used = config_path
+                            
+                            # Wait for snakemake process to start with retries
+                            import time
+                            snakemake_pid = None
+                            for attempt in range(5):  # Try 5 times
+                                time.sleep(2)  # Wait 2 seconds between attempts (total 10 seconds)
+                                snakemake_pid = self._find_snakemake_process_pid()
+                                if snakemake_pid:
+                                    print(f"DEBUG: Found snakemake PID={snakemake_pid} after {(attempt+1)*2} seconds")
+                                    break
+                                print(f"DEBUG: Attempt {attempt+1}/5: No snakemake process found yet...")
+                            
+                            if snakemake_pid:
+                                self._store_pipeline_process_info(snakemake_pid)
+                            else:
+                                print("WARNING: Could not find snakemake PID after 10 seconds")
+                                print("WARNING: Pipeline started but monitoring may not work correctly")
+                        
+                        QtWidgets.QMessageBox.information(
+                            self,
+                            "Pipeline Started",
+                            "Snakemake pipeline started in a new terminal window."
+                        )
+                    else:
+                        # For Unix-like systems
+                        self.snakemake_process = subprocess.Popen(cmd)
+                        if self.snakemake_process:
+                            self._store_pipeline_process_info(self.snakemake_process.pid)
+                        
+                        QtWidgets.QMessageBox.information(
+                            self,
+                            "Pipeline Started",
+                            f"Snakemake pipeline started."
+                        )
+                    
+                    # Start monitoring timer only for actual pipeline runs (not dry runs or summaries)
+                    if not dry_run and not show_summary:
+                        self._start_pipeline_monitoring()
+                    
+                except Exception as e:
+                    QtWidgets.QMessageBox.critical(
+                        self,
+                        "Error",
+                        f"Failed to run pipeline:\n{str(e)}"
+                    )
+    
+    def _save_homer_config(self, snakefile_path, config_path, derivatives_dir, pipeline_status=None):
+        """Save homer.config file with Snakefile, config paths, and pipeline status"""
+        try:
+            homer_config_path = os.path.join(derivatives_dir, 'homer.config')
+            homer_config = {
+                'snakefile_path': snakefile_path,
+                'config_path': config_path
+            }
+            if pipeline_status:
+                homer_config['pipeline_status'] = pipeline_status
+            with open(homer_config_path, 'w') as f:
+                yaml.dump(homer_config, f, default_flow_style=False)
+            print(f"Saved homer.config to {homer_config_path}")
+        except Exception as e:
+            print(f"Warning: Could not save homer.config: {str(e)}")
+    
+    def _auto_load_snakemake_config(self):
+        """Auto-load Snakemake configuration from homer.config if it exists"""
+        try:
+            # Only check in the selected path_to_data folder
+            if not self.path_to_data or not os.path.exists(self.path_to_data):
+                print("No path_to_data set, skipping auto-load")
+                return
+            
+            # Check for homer.config ONLY in the selected folder
+            homer_config_path = os.path.join(self.path_to_data, 'homer.config')
+            
+            if not os.path.exists(homer_config_path):
+                print(f"No homer.config found in {self.path_to_data}, skipping auto-load")
+                return
+            
+            print(f"Found homer.config at {homer_config_path}")
+            
+            with open(homer_config_path, 'r') as f:
+                homer_config = yaml.safe_load(f)
+            
+            snakefile_path = homer_config.get('snakefile_path')
+            config_path = homer_config.get('config_path')
+            
+            if snakefile_path and config_path:
+                if os.path.exists(snakefile_path) and os.path.exists(config_path):
+                    print(f"Auto-loading Snakemake config from homer.config")
+                    self._load_snakemake_config(snakefile_path, config_path)
+                else:
+                    print(f"Warning: Paths in homer.config not found")
+                    if not os.path.exists(snakefile_path):
+                        print(f"  Snakefile not found: {snakefile_path}")
+                    if not os.path.exists(config_path):
+                        print(f"  Config not found: {config_path}")
+        except Exception as e:
+            print(f"Warning: Could not auto-load homer.config: {str(e)}")
+    
+    def _load_snakemake_config(self, snakefile_path, config_path):
+        """Load Snakemake config and update menu dynamically"""
+        try:
+            if not os.path.exists(config_path):
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Config Not Found",
+                    f"Config file not found at:\n{config_path}"
+                )
+                return
+            
+            # Load the config
+            with open(config_path, 'r') as f:
+                self.snakemake_config = yaml.safe_load(f)
+            
+            self.snakefile_path = snakefile_path
+            self.snakemake_config_path = config_path
+            
+            # Load file status maps (current scope + full scope)
+            self._load_file_status_maps()
+            
+            # Rebuild the menu
+            self._rebuild_snakemake_menu()
+            
+            self.statbar.showMessage(f"Loaded config from {os.path.basename(config_path)}")
+            
+        except Exception as e:
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Error Loading Config",
+                f"Failed to load config:\n{str(e)}"
+            )
+    
+    def _rebuild_snakemake_menu(self):
+        """Rebuild Snakemake menu based on loaded config"""
+        if not self.snakemake_menu or not self.snakemake_config:
+            return
+        
+        # Remove all dynamic menu items
+        for action in self.dynamic_menu_actions:
+            self.snakemake_menu.removeAction(action)
+        self.dynamic_menu_actions.clear()
+        
+        # Find the Dataset action to insert dynamic items after it
+        dataset_action = None
+        second_separator = None
+        found_first_separator = False
+        
+        for action in self.snakemake_menu.actions():
+            if action.text() == "Dataset":
+                dataset_action = action
+            # Find the second separator (the one before Run Pipeline)
+            if action.isSeparator():
+                if found_first_separator:
+                    second_separator = action
+                    break
+                else:
+                    found_first_separator = True
+        
+        # Add menu items for each config block (except 'dataset')
+        # Preserve order from config file
+        insert_after = dataset_action
+        for block_name in self.snakemake_config.keys():
+            if block_name == 'dataset':
+                continue  # Already have Dataset menu item
+            
+            # Create a friendly display name
+            display_name = block_name.replace('_', ' ').title()
+            
+            action = QAction(display_name, self)
+            action.setStatusTip(f"{display_name} configuration")
+            action.triggered.connect(lambda checked, bn=block_name: self._snakemake_config_item(bn))
+            
+            # Insert after the previous action (Dataset or last dynamic item)
+            if insert_after:
+                self.snakemake_menu.insertAction(self._get_next_action(insert_after), action)
+            else:
+                self.snakemake_menu.addAction(action)
+            
+            self.dynamic_menu_actions.append(action)
+            insert_after = action  # Next item inserts after this one
+        
+        # Add Refresh Colors action before the second separator (Run Pipeline)
+        if second_separator:
+            refresh_action = QAction("Refresh File Status", self)
+            refresh_action.setStatusTip("Manually refresh file processing status and colors")
+            refresh_action.triggered.connect(self._manual_refresh_colors)
+            self.snakemake_menu.insertAction(second_separator, refresh_action)
+            self.dynamic_menu_actions.append(refresh_action)
+            
+            # Add Stop Monitoring action
+            stop_action = QAction("Stop Monitoring", self)
+            stop_action.setStatusTip("Stop automatic pipeline monitoring")
+            stop_action.triggered.connect(self._stop_pipeline_monitoring)
+            self.snakemake_menu.insertAction(second_separator, stop_action)
+            self.dynamic_menu_actions.append(stop_action)
+    
+    def _manual_refresh_colors(self):
+        """Manually trigger a refresh of file colors"""
+        self._update_all_file_colors()
+        self.statbar.showMessage("File status refreshed")
+    
+    def _get_next_action(self, action):
+        """Get the action that comes after the given action in the menu"""
+        actions = self.snakemake_menu.actions()
+        try:
+            idx = actions.index(action)
+            if idx + 1 < len(actions):
+                return actions[idx + 1]
+        except (ValueError, IndexError):
+            pass
+        return None
+    
+    def _edit_config_minimal_dataset(self, config_path):
+        """Edit only root_dir and derivatives_subfolder for dataset before config is loaded"""
+        try:
+            # Check if file exists, if not create a minimal one
+            if not os.path.exists(config_path):
+                # Create directory if needed
+                os.makedirs(os.path.dirname(config_path), exist_ok=True)
+                
+                # Create minimal config with just dataset
+                minimal_config = {
+                    'dataset': {
+                        'root_dir': '',
+                        'derivatives_subfolder': ''
+                    }
+                }
+                with open(config_path, 'w') as f:
+                    yaml.dump(minimal_config, f, default_flow_style=False)
+            
+            # Load existing config
+            with open(config_path, 'r') as f:
+                full_config = yaml.safe_load(f)
+            
+            if 'dataset' not in full_config:
+                full_config['dataset'] = {}
+            
+            # Extract only root_dir and derivatives_subfolder
+            minimal_data = {
+                'root_dir': full_config['dataset'].get('root_dir', ''),
+                'derivatives_subfolder': full_config['dataset'].get('derivatives_subfolder', '')
+            }
+            
+            # Open editor dialog with only these two fields
+            dialog = ConfigEditorDialog(minimal_data, 'dataset (basic)', readonly_keys=None, field_tooltips=None, parent=self)
+            
+            if dialog.exec() == QtWidgets.QDialog.Accepted:
+                # Get updated data
+                updated_data = dialog.get_updated_data()
+                
+                # Update only these fields in the full config
+                full_config['dataset']['root_dir'] = updated_data.get('root_dir', '')
+                full_config['dataset']['derivatives_subfolder'] = updated_data.get('derivatives_subfolder', '')
+                
+                # Save back to file
+                with open(config_path, 'w') as f:
+                    yaml.dump(full_config, f, default_flow_style=False, sort_keys=False)
+                
+                self.statbar.showMessage("Dataset configuration saved!")
+                
+        except Exception as e:
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Error",
+                f"Error editing configuration:\n{str(e)}"
+            )
+    
+    def _edit_config_block(self, config_path, block_name, readonly_keys=None):
+        """Load, edit, and save a specific block from config file"""
+        try:
+            print(f"DEBUG: Checking for config file at: {config_path}")
+            print(f"DEBUG: File exists: {os.path.exists(config_path)}")
+            # Check if file exists
+            if not os.path.exists(config_path):
+                QtWidgets.QMessageBox.warning(
+                    self, 
+                    "Config File Not Found",
+                    f"Could not find config file at:\n{config_path}"
+                )
+                return
+            
+            # Read the original file to preserve comments
+            with open(config_path, 'r') as f:
+                original_content = f.read()
+                original_lines = original_content.splitlines()
+            
+            # Load the config data
+            with open(config_path, 'r') as f:
+                full_config = yaml.safe_load(f)
+            
+            if block_name not in full_config:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Block Not Found",
+                    f"Block '{block_name}' not found in config file"
+                )
+                return
+            
+            # Get the specific block
+            block_data = full_config[block_name]
+            
+            # Extract field tooltips from comments
+            field_tooltips = self._extract_field_comments(original_lines, block_name)
+            
+            # Open editor dialog
+            dialog = ConfigEditorDialog(block_data, block_name, readonly_keys, field_tooltips, self)
+            
+            if dialog.exec() == QtWidgets.QDialog.Accepted:
+                # Get updated data
+                updated_block = dialog.get_updated_data()
+                
+                # Update the full config with the edited block
+                full_config[block_name] = updated_block
+                
+                # Save back to file, preserving comments and formatting where possible
+                self._save_yaml_with_comments(config_path, full_config, original_lines, block_name)
+                
+                self.statbar.showMessage(f"{block_name.replace('_', ' ').title()} configuration saved!")
+                
+        except Exception as e:
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Error",
+                f"Error editing configuration:\n{str(e)}"
+            )
+
+    def _extract_field_comments(self, original_lines, block_name):
+        """Extract comments from YAML file and map them to field keys"""
+        field_comments = {}
+        
+        # Find the block in the file
+        in_block = False
+        block_indent = 0
+        pending_comment = None
+        
+        for i, line in enumerate(original_lines):
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            
+            # Check if we're entering the target block
+            if stripped.startswith(f"{block_name}:"):
+                in_block = True
+                block_indent = indent
+                # Check for inline comment on the block declaration line
+                if '#' in line:
+                    comment_part = line.split('#', 1)[1].strip()
+                    if comment_part:
+                        field_comments['__block__'] = comment_part
+                continue
+            
+            if not in_block:
+                continue
+            
+            # Check if we've exited the block (another top-level key at same or lower indent)
+            if stripped and not stripped.startswith('#') and indent <= block_indent:
+                break
+            
+            # Skip empty lines
+            if not stripped:
+                pending_comment = None
+                continue
+            
+            # Check for standalone comment line (comment for the next field)
+            if stripped.startswith('#'):
+                comment = stripped[1:].strip()
+                pending_comment = comment
+                continue
+            
+            # This is a field line with a key
+            if ':' in line:
+                # Extract field name
+                field_part = line.split('#')[0]  # Remove inline comment first
+                field_name = field_part.split(':')[0].strip()
+                
+                # Check for inline comment (comment on same line as field)
+                if '#' in line:
+                    inline_comment = line.split('#', 1)[1].strip()
+                    if inline_comment:
+                        field_comments[field_name] = inline_comment
+                        pending_comment = None  # Clear pending since we used inline
+                        continue
+                
+                # Use pending comment if no inline comment
+                if pending_comment:
+                    field_comments[field_name] = pending_comment
+                    pending_comment = None
+        
+        print(f"DEBUG: Extracted comments for {block_name}: {field_comments}")
+        return field_comments
+    
+    def _save_yaml_with_comments(self, config_path, full_config, original_lines, modified_block):
+        """Save YAML config while preserving comments and quote styles"""
+        # Find where the modified block starts and ends in the original file
+        block_start = -1
+        block_indent = 0
+        
+        for i, line in enumerate(original_lines):
+            stripped = line.lstrip()
+            if stripped.startswith(f"{modified_block}:"):
+                block_start = i
+                block_indent = len(line) - len(stripped)
+                break
+        
+        if block_start == -1:
+            # Fallback to standard YAML dump if we can't find the block
+            with open(config_path, 'w') as f:
+                yaml.dump(full_config, f, default_flow_style=False, sort_keys=False)
+            return
+        
+        # Find block end (next top-level key or end of file)
+        block_end = len(original_lines)
+        for i in range(block_start + 1, len(original_lines)):
+            line = original_lines[i]
+            if line.strip() and not line.startswith(' ') and not line.strip().startswith('#'):
+                block_end = i
+                break
+        
+        # Extract comments and quote styles from the modified block
+        block_comments = {}
+        quoted_values = set()  # Track which values were originally quoted
+        list_quote_patterns = {}  # Track which list keys had quoted items
+        
+        for i in range(block_start, block_end):
+            line = original_lines[i]
+            
+            # Check for lists with quoted strings
+            if '[' in line and ']' in line:
+                # Extract the key for this list
+                key_match = re.match(r'\s*([^:]+):\s*\[', line)
+                if key_match:
+                    list_key = key_match.group(1).strip()
+                    # Check if any items in the list are quoted
+                    if '"' in line or "'" in line:
+                        list_quote_patterns[list_key] = True
+            
+            # Check for quoted strings in the original
+            if '"' in line or "'" in line:
+                # Find all quoted strings in this line
+                quoted_matches = re.findall(r'["\']([^"\']+)["\']', line)
+                quoted_values.update(quoted_matches)
+            
+            if '#' in line:
+                # Extract the key and comment
+                before_comment = line.split('#')[0]
+                comment = '#' + '#'.join(line.split('#')[1:])
+                
+                # Try to find the key
+                match = re.match(r'\s*([^:]+):', before_comment)
+                if match:
+                    key = match.group(1).strip()
+                    block_comments[key] = comment
+        
+        # Generate new YAML for the modified block
+        block_yaml_lines = []
+        block_data = full_config[modified_block]
+        
+        # Track which keys should have quoted list items
+        current_list_key = None
+        
+        # Use a custom dumper to preserve quote styles
+        class QuotePreservingDumper(yaml.SafeDumper):
+            pass
+        
+        def represent_str(dumper, data):
+            # If this value was originally quoted, keep quotes
+            if data in quoted_values:
+                return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='"')
+            
+            # Check if string needs quotes (has special chars, spaces, etc.)
+            if any(char in data for char in [' ', ':', '#', '-', '[', ']', '{', '}', '!', '*', '&', '/', '.']):
+                # Use double quotes for strings with special characters
+                return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='"')
+            
+            # Check if it looks like a boolean or number
+            if data.lower() in ['true', 'false', 'yes', 'no', 'on', 'off']:
+                return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='"')
+            
+            try:
+                float(data)
+                return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='"')
+            except ValueError:
+                pass
+            
+            return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+        
+        def represent_list(dumper, data):
+            # Keep lists inline (flow style) like [item1, item2]
+            return dumper.represent_sequence('tag:yaml.org,2002:seq', data, flow_style=True)
+        
+        QuotePreservingDumper.add_representer(str, represent_str)
+        QuotePreservingDumper.add_representer(list, represent_list)
+        
+        # Dump just the block data
+        block_yaml = yaml.dump({modified_block: block_data}, 
+                               Dumper=QuotePreservingDumper, 
+                               default_flow_style=False, 
+                               sort_keys=False)
+        
+        block_yaml_lines = block_yaml.splitlines()
+        
+        # Post-process lines to add quotes to list items if the original had them
+        for i, line in enumerate(block_yaml_lines):
+            if '[' in line and ']' in line:
+                # This is a list line
+                key_match = re.match(r'\s*([^:]+):\s*\[', line)
+                if key_match:
+                    list_key = key_match.group(1).strip()
+                    # If this list originally had quoted items, add quotes to all items
+                    if list_key in list_quote_patterns:
+                        # Extract the list content
+                        list_match = re.search(r'\[(.*?)\]', line)
+                        if list_match:
+                            list_content = list_match.group(1)
+                            # Split by comma and process each item
+                            items = [item.strip() for item in list_content.split(',')]
+                            # Add quotes to items that don't already have them
+                            quoted_items = []
+                            for item in items:
+                                if item and not (item.startswith('"') or item.startswith("'")):
+                                    quoted_items.append(f'"{item}"')
+                                else:
+                                    quoted_items.append(item)
+                            # Reconstruct the line
+                            before_list = line[:line.index('[') + 1]
+                            after_list = ']' + line[line.rindex(']') + 1:]
+                            block_yaml_lines[i] = before_list + ', '.join(quoted_items) + after_list
+        
+        # Re-attach comments to matching keys
+        for i, line in enumerate(block_yaml_lines):
+            if ':' in line and not line.strip().startswith('#'):
+                match = re.match(r'\s*([^:]+):', line)
+                if match:
+                    key = match.group(1).strip()
+                    if key in block_comments:
+                        # Append the comment to the line
+                        block_yaml_lines[i] = line.rstrip() + '  ' + block_comments[key]
+        
+        # Reconstruct the full file
+        new_lines = (
+            original_lines[:block_start] +
+            block_yaml_lines +
+            original_lines[block_end:]
+        )
+        
+        # Write back to file
+        with open(config_path, 'w') as f:
+            f.write('\n'.join(new_lines))
+            if new_lines:  # Add final newline if there's content
+                f.write('\n')
+
+    def _init_widgets(self, redraw_optodes=True):
+        """Initializes widgets based on the current prepared data."""
+        if redraw_optodes:
+            self.optodes_drawn = False
+
+        # Clear any existing channel highlights first
+        if hasattr(self, 'chan_highlight') and self.chan_highlight:
+            for line in self.chan_highlight:
+                try:
+                    line.remove()
+                except:
+                    pass
+        
+        # Initialize holders to control each part of the plot first
+        self.src_label = [0] * len(self.sx)
+        self.det_label = [0] * len(self.dx)
+        self.chan_highlight = []
+        self.aux_sel = []
+        self.auxplot = []
+        self.aux_type = None
+        self.aux_rect_width = 0
+        
+        # Track selected channels directly (for line picking)
+        self.selected_channels = []
+        
+        # Update stimulus types if we have stimulus data
+        self._update_stim_types()
+        
+        # Block signals to prevent premature updates
+        self.ts.blockSignals(True)
+        self.auxs.blockSignals(True)
+
+        # Reset and populate widgets
+        self.ts.clear()
+        self.ts.addItems(["None"])
+        self.ts.addItems(self.timeseries_keys)
+        
+        self.auxs.clear()
+        self.auxs.addItems(["None"])
+        self.auxs.addItems(self.aux_ts_keys)
+
+        # Safely unblock signals
+        self.ts.blockSignals(False)
+        self.auxs.blockSignals(False)
+
+        # Update stimulus selection based on available data
+        self._update_stim_types()
+        
+        # Enable/disable HRF view checkbox based on data availability
+        # and determine which stimulus types have HRF data
+        # HRF should be enabled if either individual data OR group average is available
+        hrf_available = False
+        
+        if self.hrf_group_avg.isChecked():
+            # When group average is checked, keep HRF view enabled
+            hrf_available = True
+            # Try to load group average to get available stim types
+            group_avg = self._load_group_average_hrf()
+            if group_avg is not None:
+                if isinstance(group_avg, dict):
+                    hrf_est = group_avg.get('hrf_est') or group_avg.get('groupaverage') or group_avg.get('data')
+                    for key, value in group_avg.items():
+                        if hrf_est is None and hasattr(value, 'dims'):
+                            hrf_est = value
+                            break
+                else:
+                    # If it's an xarray Dataset, extract the data variable
+                    if hasattr(group_avg, 'data_vars'):
+                        # It's an xarray Dataset, extract the data variable
+                        if 'hrf_est' in group_avg.data_vars:
+                            hrf_est = group_avg['hrf_est']
+                        elif 'group_average' in group_avg.data_vars:
+                            hrf_est = group_avg['group_average']
+                        elif 'hrf_estimate' in group_avg.data_vars:
+                            hrf_est = group_avg['hrf_estimate']
+                        else:
+                            # Use the first data variable
+                            first_var = list(group_avg.data_vars.keys())[0]
+                            hrf_est = group_avg[first_var]
+                    else:
+                        # It's already a DataArray
+                        hrf_est = group_avg
+                    
+                if hrf_est is not None and hasattr(hrf_est, 'coords') and 'trial_type' in hrf_est.coords:
+                    self.hrf_available_stim_types = list(hrf_est.coords['trial_type'].values)
+                else:
+                    self.hrf_available_stim_types = []
+            else:
+                self.hrf_available_stim_types = []
+        elif hasattr(self, 'hrf_data') and self.hrf_data is not None:
+            hrf_available = True
+            print(f"DEBUG: HRF data found, enabling checkbox")
+            # Get available stimulus types from HRF data
+            hrf_est = self.hrf_data.get('hrf_est')
+            if hrf_est is not None and 'trial_type' in hrf_est.coords:
+                self.hrf_available_stim_types = list(hrf_est.coords['trial_type'].values)
+            else:
+                self.hrf_available_stim_types = []
+        else:
+            self.hrf_available_stim_types = []
+            print(f"DEBUG: No HRF data found, checkbox will be disabled")
+        
+        if hrf_available:
+            self.hrf_view.setEnabled(True)
+        else:
+            self.hrf_view.setEnabled(False)
+            self.hrf_view.setChecked(False)
+
+        # Reset selection and data
+        self.selected = []
+        self.snirfData = None
+        if redraw_optodes:
+            self._draw_optodes()
+
+    def _draw_optodes(self):
+        if self.optodes_drawn:
+            return
+
+        self._optode_ax.clear()
+
+        self.picker = self._optode_ax.scatter(
+            self.sdx,
+            self.sdy,
+            color=[[0, 0, 0, 0]] * (len(self.sx) + len(self.dx)),
+            zorder=10,  # Higher zorder to prioritize over channel lines
+            picker=6,   # Reduced from 8 for more precise clicking
+        )
+
+        self.optodes = self._optode_ax.scatter(
+            self.sdx,
+            self.sdy,
+            color=["r"] * len(self.sx) + ["b"] * len(self.dx),
+            zorder=15,  # Higher than channel lines (1) and picker (10)
+            visible=False,
+        )
+
+        for idx, source in enumerate(self.sPos.label):
+            self.src_label[idx] = self._optode_ax.text(
+                self.sx[idx],
+                self.sy[idx],
+                f"{source.values}",
+                color="r",
+                fontsize=8,
+                ha="center",
+                va="center",
+                zorder=20,  # Highest z-order so text is always visible
+                clip_on=True,
+            )
+
+        for idx, detector in enumerate(self.dPos.label):
+            self.det_label[idx] = self._optode_ax.text(
+                self.dx[idx],
+                self.dy[idx],
+                f"{detector.values}",
+                color="b",
+                fontsize=8,
+                ha="center",
+                va="center",
+                zorder=20,  # Highest z-order so text is always visible
+                clip_on=True,
+            )
+
+        # Store channel lines for picking
+        self.channel_lines = []
+        for i_ch in range(self.no_channels):
+            si = self.src_idx[i_ch]
+            di = self.det_idx[i_ch]
+
+            line, = self._optode_ax.plot(
+                [self.sx[si], self.dx[di]],
+                [self.sy[si], self.dy[di]],
+                "-",
+                color=[0.8, 0.8, 0.8],
+                zorder=1,
+                picker=True,  # Enable picking but with very precise detection
+                pickradius=1,  # Very small radius for precise line selection
+                linewidth=2  # Make lines slightly thicker for easier clicking
+            )
+            # Store the line with its channel index
+            line.channel_index = i_ch
+            self.channel_lines.append(line)
+
+        self.optodes_drawn = True
+
+        self._optode_ax.set_aspect("equal")
+        self._optode_ax.axis("off")
+        self._optode_ax.figure.canvas.draw()
+
+    def _shift_is_pressed(self, event):
+        if (not self.shift_pressed) and event.key == "shift":
+            self.shift_pressed = True
+        else:
+            return
+
+    def _shift_is_released(self, event):
+        if self.shift_pressed and event.key == "shift":
+            self.shift_pressed = False
+        else:
+            return
+
+    def _optode_picked(self, event):
+        if self.ts.currentItem() is None or self.ts.currentItem().text() == "None":
+            return
+
+        # Debug: Print what was clicked
+        # print(f"Clicked on: {type(event.artist)}, has channel_index: {hasattr(event.artist, 'channel_index')}")
+        
+        # Check if an optode was clicked (prioritize optodes over channel lines)
+        if event.artist == self.picker:
+            self._optode_scatter_picked(event)
+            return  # Exit early to prevent line selection
+        # Check if a channel line was clicked
+        elif hasattr(event.artist, 'channel_index'):
+            self._channel_line_picked(event)
+            return  # Exit early to prevent optode selection
+
+    def _channel_line_picked(self, event):
+        """Handle clicking on channel lines for direct channel selection"""
+        channel_idx = event.artist.channel_index
+        
+        # Check if Shift key is held down
+        shift_pressed = event.mouseevent.key == 'shift'
+        
+        if shift_pressed:
+            # Shift+click: Toggle channel selection
+            if channel_idx in self.selected_channels:
+                self.selected_channels.remove(channel_idx)
+            else:
+                self.selected_channels.append(channel_idx)
+        else:
+            # Regular click: Clear previous selection and select only this channel
+            self.selected_channels = [channel_idx]
+        
+        self._draw_timeseries()
+
+    def _optode_scatter_picked(self, event):
+        """Handle clicking on optodes - toggles channels from optode in selection"""
+        if not hasattr(self, 'snirfData') or self.snirfData is None:
+            return
+            
+        N = len(event.ind)
+        if not N:
+            return
+
+        # Click location
+        x = event.mouseevent.xdata
+        y = event.mouseevent.ydata
+
+        distances = np.hypot(x - self.sdx[event.ind], y - self.sdy[event.ind])
+        indmin = distances.argmin()
+        dataind = event.ind[indmin]
+
+        # Get channels connected to this optode
+        opt_label = self.opt_label[dataind]
+        
+        if "S" in opt_label:
+            # Source optode - find all channels with this source
+            channels_from_optode = self.snirfData.source[
+                self.snirfData.source == opt_label
+            ].channel.values.tolist()
+        elif "D" in opt_label:
+            # Detector optode - find all channels with this detector
+            channels_from_optode = self.snirfData.detector[
+                self.snirfData.detector == opt_label
+            ].channel.values.tolist()
+        else:
+            channels_from_optode = []
+            
+        # Convert channel names to indices
+        channel_indices = []
+        for chan in channels_from_optode:
+            chan_idx = np.where(self.snirfData.channel.values == chan)[0]
+            if len(chan_idx) > 0:
+                channel_indices.append(chan_idx[0])
+        
+        # Check if Shift key is held down
+        shift_pressed = event.mouseevent.key == 'shift'
+        
+        if shift_pressed:
+            # Shift+click: Toggle channels from this optode
+            already_selected = any(idx in self.selected_channels for idx in channel_indices)
+            
+            if already_selected:
+                # Remove all channels from this optode
+                for idx in channel_indices:
+                    if idx in self.selected_channels:
+                        self.selected_channels.remove(idx)
+            else:
+                # Add all channels from this optode
+                for idx in channel_indices:
+                    if idx not in self.selected_channels:
+                        self.selected_channels.append(idx)
+        else:
+            # Regular click: Clear previous selection and select only channels from this optode
+            self.selected_channels = channel_indices.copy()
+        
+        # Clear old optode selection method - we now use unified channel selection
+        self.selected = []
+        
+        self._draw_timeseries()
+
+    def _toggle_circles(self):
+        if self.opt2circ.isChecked():
+            for idx, source in enumerate(self.sPos.label):
+                self.src_label[idx].set_visible(False)
+            for idx, detector in enumerate(self.dPos.label):
+                self.det_label[idx].set_visible(False)
+
+            self.optodes.set_visible(True)
+        else:
+            for idx, source in enumerate(self.sPos.label):
+                self.src_label[idx].set_visible(True)
+            for idx, detector in enumerate(self.dPos.label):
+                self.det_label[idx].set_visible(True)
+
+            self.optodes.set_visible(False)
+
+        self._optode_ax.figure.canvas.draw()
+
+    def _toggle_hrf_view(self):
+        """Toggle between time series and HRF display"""
+        if self.hrf_view.isChecked():
+            # When enabling HRF view, select all available HRF stimuli
+            if hasattr(self, 'hrf_available_stim_types') and self.hrf_available_stim_types:
+                self.selected_stim_types = set(self.hrf_available_stim_types)
+                self._update_stim_button_text()
+            # Enable chromophore checkboxes
+            self.hrf_hbo.setEnabled(True)
+            self.hrf_hbr.setEnabled(True)
+            self.launch_plot_probe_btn.setEnabled(True)
+            # If group average is checked, disable subject/run dropdowns
+            if self.hrf_group_avg.isChecked():
+                self.subj.setEnabled(False)
+                self.run.setEnabled(False)
+        else:
+            # When disabling HRF view, clear all stimulus selections
+            self.selected_stim_types = set()
+            self._update_stim_button_text()
+            # Disable chromophore checkboxes
+            self.hrf_hbo.setEnabled(False)
+            self.hrf_hbr.setEnabled(False)
+            self.launch_plot_probe_btn.setEnabled(False)
+            # Re-enable subject/run dropdowns
+            self.subj.setEnabled(True)
+            self.run.setEnabled(True)
+        
+        # Update file colors to reflect the new view mode
+        self._update_all_file_colors()
+        self._update_combobox_selection_colors()
+        
+        self._draw_timeseries()
+    
+    def _hrf_group_avg_changed(self):
+        """Handle changes to HRF group average checkbox"""
+        print(f"Group average checkbox changed to: {self.hrf_group_avg.isChecked()}")
+        if self.hrf_group_avg.isChecked():
+            # Disable subject and run selectors when group average is active
+            self.subj.setEnabled(False)
+            self.run.setEnabled(False)
+        else:
+            # Re-enable subject and run selectors
+            self.subj.setEnabled(True)
+            self.run.setEnabled(True)
+        
+        # Redraw if HRF view is active
+        if self.hrf_view.isChecked():
+            print("Calling _draw_timeseries from _hrf_group_avg_changed")
+            self._draw_timeseries()
+    
+    def _hrf_chromo_changed(self):
+        """Handle changes to HRF chromophore selection"""
+        if self.hrf_view.isChecked():
+            self._draw_timeseries()
+    
+    def _launch_plot_probe(self):
+        """Launch the Plot Probe GUI with current HRF data"""
+        print("Launching Plot Probe GUI...")
+        
+        # Get HRF data based on group average checkbox state
+        if self.hrf_group_avg.isChecked():
+            print("Loading group average HRF data for Plot Probe")
+            hrf_data = self._load_group_average_hrf()
+            if hrf_data is None:
+                self.statbar.showMessage("No group average HRF data found")
+                return
+        else:
+            print("Using individual HRF data for Plot Probe")
+            # Use the already-loaded hrf_data from the current subject/run
+            if not hasattr(self, 'hrf_data') or self.hrf_data is None:
+                self.statbar.showMessage("No HRF data found for current selection")
+                return
+            hrf_data = self.hrf_data
+            print(f"DEBUG: hrf_data type = {type(hrf_data)}")
+            if isinstance(hrf_data, dict):
+                print(f"DEBUG: hrf_data is dict with keys: {list(hrf_data.keys())}")
+            elif hasattr(hrf_data, 'dims'):
+                print(f"DEBUG: hrf_data is xarray with dims: {hrf_data.dims}")
+        
+        # Extract the actual xarray DataArray from the loaded data
+        blockaverage = None
+        stderr = None
+        
+        if hasattr(hrf_data, 'data_vars'):
+            # It's an xarray Dataset, extract the data variable
+            print(f"HRF data is a Dataset with variables: {list(hrf_data.data_vars.keys())}")
+            if 'hrf_est' in hrf_data.data_vars:
+                blockaverage = hrf_data['hrf_est']
+            elif 'group_average' in hrf_data.data_vars:
+                blockaverage = hrf_data['group_average']
+            elif 'hrf_estimate' in hrf_data.data_vars:
+                blockaverage = hrf_data['hrf_estimate']
+            else:
+                # Use the first data variable
+                first_var = list(hrf_data.data_vars.keys())[0]
+                blockaverage = hrf_data[first_var]
+                print(f"Using first data variable: {first_var}")
+        elif hasattr(hrf_data, 'dims'):
+            # It's already an xarray DataArray
+            print("HRF data is already a DataArray")
+            blockaverage = hrf_data
+        elif isinstance(hrf_data, dict):
+            print("HRF data is a dict, extracting hrf_est")
+            blockaverage = hrf_data.get('hrf_est') 
+            if blockaverage is None:
+                blockaverage = hrf_data.get('groupaverage')
+            if blockaverage is None:
+                blockaverage = hrf_data.get('data')
+            if blockaverage is None:
+                # Look for first xarray object in dict
+                for key, value in hrf_data.items():
+                    if hasattr(value, 'dims'):
+                        blockaverage = value
+                        print(f"Found xarray data in key: {key}")
+                        break
+            
+            # Extract standard error from total_stderr (group average) or mse_t (individual HRF)
+            if 'total_stderr' in hrf_data:
+                # Group average data has total_stderr already computed
+                stderr = hrf_data['total_stderr']
+                print(f"Found total_stderr with dims: {stderr.dims}")
+            elif 'mse_t' in hrf_data:
+                # Individual HRF data has mse_t which we convert to stderr
+                import numpy as np
+                mse_t = hrf_data['mse_t']
+                print(f"Found mse_t with dims: {mse_t.dims}")
+                
+                # Compute standard error: stderr = sqrt(mse_t)
+                stderr = np.sqrt(mse_t)
+                
+                # Transpose to match blockaverage dimensions if needed
+                # blockaverage dims: ('trial_type', 'channel', 'chromo', 'time')
+                # mse_t dims: ('trial_type', 'time', 'channel', 'chromo')
+                if blockaverage is not None and hasattr(blockaverage, 'dims'):
+                    target_dims = blockaverage.dims
+                    if stderr.dims != target_dims:
+                        stderr = stderr.transpose(*target_dims)
+                        print(f"Transposed stderr to dims: {stderr.dims}")
+                
+                print(f"Standard error computed and ready to pass to plot_probe")
+        
+        if blockaverage is None or not hasattr(blockaverage, 'dims'):
+            self.statbar.showMessage("Invalid HRF data format")
+            return
+        
+        # Get geometry from snirfRec
+        if self.snirfRec is None:
+            self.statbar.showMessage("No recording loaded - geometry not available")
+            return
+        
+        if not hasattr(self.snirfRec, 'geo2d') or not hasattr(self.snirfRec, 'geo3d'):
+            self.statbar.showMessage("Recording missing geometry information")
+            return
+        
+        geo2d = self.snirfRec.geo2d
+        geo3d = self.snirfRec.geo3d
+        
+        # Import and launch the plot_probe_gui
+        try:
+            from cedalion.vis.misc.plot_probe_gui import _MAIN_GUI
+            print(f"Launching with HRF data dims: {blockaverage.dims}")
+            if stderr is not None:
+                print(f"Passing stderr with dims: {stderr.dims}")
+            
+            # Create the Plot Probe GUI as a child window (don't create new QApplication)
+            self.plot_probe_window = _MAIN_GUI(
+                snirfData=blockaverage, 
+                stderr=stderr, 
+                geo2d=geo2d, 
+                geo3d=geo3d
+            )
+            self.plot_probe_window.show()
+            
+        except Exception as e:
+            print(f"Error launching Plot Probe GUI: {e}")
+            import traceback
+            traceback.print_exc()
+            self.statbar.showMessage(f"Error launching Plot Probe: {str(e)}")
+
+    def _launch_image_recon(self):
+        """Launch the Image Reconstruction viewer with current task data"""
+        print("Launching Image Reconstruction...")
+        
+        # Get the current task name from the current data file path
+        task_name = None
+        base_path = None
+        
+        # Get current subject and run from combo boxes
+        current_subject = self.subj.currentText() if self.subj.currentText() != "None" else None
+        current_run = self.run.currentText() if self.run.currentText() != "None" else None
+        
+        print(f"DEBUG: current_subject={current_subject}, current_run={current_run}")
+        
+        # Try to extract from the file_map using current subject/run
+        if current_subject and current_run:
+            file_info = self.file_map.get(current_subject, {}).get(current_run, {})
+            print(f"DEBUG: file_info keys: {list(file_info.keys()) if file_info else 'None'}")
+            # Try different possible keys for the path
+            pkl_path = None
+            if file_info:
+                pkl_path = (file_info.get('preprocessing_snirfData') or 
+                           file_info.get('pkl_path') or 
+                           file_info.get('snirf_path'))
+            
+            if pkl_path:
+                print(f"DEBUG: pkl_path={pkl_path}")
+                task_match = re.search(r'task-([^_/\\]+)', pkl_path)
+                task_name = task_match.group(1) if task_match else None
+                
+                # Get base path - extract up to config folder
+                # Path structure: .../derivatives/cedalion/{config_name}/...
+                # We want everything up to and including {config_name}
+                derivatives_match = re.search(r'(.*[/\\]derivatives[/\\]cedalion[/\\][^/\\]+)', pkl_path)
+                if derivatives_match:
+                    base_path = derivatives_match.group(1)
+                    # Normalize to forward slashes for consistency
+                    base_path = base_path.replace('\\', '/')
+                    print(f"DEBUG: Extracted base_path={base_path}")
+                else:
+                    print(f"DEBUG: Could not extract base_path from pkl_path")
+        
+        print(f"DEBUG: task_name={task_name}, base_path={base_path}")
+        
+        if not task_name or not base_path:
+            msg = "Cannot determine task name or base path. Please load data first."
+            print(f"ERROR: {msg}")
+            self.statbar.showMessage(msg)
+            return
+        
+        print(f"Task: {task_name}, Base path: {base_path}")
+        
+        # Check if image_results directory exists
+        image_results_dir = os.path.join(base_path, 'image_results')
+        print(f"DEBUG: Checking for image_results at: {image_results_dir}")
+        if not os.path.exists(image_results_dir):
+            msg = f"Image results directory not found: {image_results_dir}"
+            print(f"ERROR: {msg}")
+            self.statbar.showMessage(msg)
+            return
+        
+        print("DEBUG: image_results directory exists, loading data...")
+        
+        # Load image reconstruction data
+        img_data = None
+        if self.hrf_group_avg.isChecked():
+            # Load group average image recon
+            print("Loading group average image reconstruction")
+            # Look for .nc files
+            pattern_nc = f"Xs_groupavg_{task_name}_*.nc"
+            import glob
+            files = glob.glob(os.path.join(image_results_dir, pattern_nc))
+            
+            if files:
+                img_path = files[0]
+                print(f"Loading: {img_path}")
+                img_data = xr.open_dataset(img_path)
+                print(f"DEBUG: Successfully loaded group average data (netCDF)")
+                print(f"DEBUG: Dataset variables: {list(img_data.data_vars.keys())}")
+            else:
+                msg = f"No group average image recon found for task {task_name}"
+                print(f"ERROR: {msg}")
+                self.statbar.showMessage(msg)
+                return
+        else:
+            # Load individual subject image recon
+            if not current_subject:
+                self.statbar.showMessage("No subject selected")
+                return
+            print(f"Loading image reconstruction for {current_subject}")
+            subj_dir = os.path.join(image_results_dir, current_subject)
+            if not os.path.exists(subj_dir):
+                self.statbar.showMessage(f"No image results for {current_subject}")
+                return
+            
+            pattern = f"Xs_{current_subject}_{task_name}_*.nc"
+            import glob
+            files = glob.glob(os.path.join(subj_dir, pattern))
+            print(f"DEBUG: Found {len(files)} files matching pattern: {pattern}")
+            if files:
+                img_path = files[0]
+                print(f"Loading: {img_path}")
+                img_data = xr.open_dataset(img_path)
+                print(f"DEBUG: Successfully loaded data from {img_path} (netCDF)")
+                print(f"DEBUG: Dataset variables: {list(img_data.data_vars.keys())}")
+            else:
+                msg = f"No image recon found for {current_subject}, task {task_name}"
+                print(f"ERROR: {msg}")
+                self.statbar.showMessage(msg)
+                return
+        
+        print(f"DEBUG: Checking img_data...")
+        print(f"DEBUG: img_data type: {type(img_data)}")
+        
+        # img_data is now an xarray Dataset (from netCDF)
+        if img_data is None:
+            msg = "Invalid image reconstruction data format. Data is None."
+            print(f"ERROR: {msg}")
+            self.statbar.showMessage(msg)
+            return
+        
+        # Check for required data variables in the Dataset
+        if not isinstance(img_data, xr.Dataset):
+            msg = f"Invalid image reconstruction data format. Expected xarray.Dataset, got {type(img_data)}."
+            print(f"ERROR: {msg}")
+            self.statbar.showMessage(msg)
+            return
+        
+        has_data = 'Xs' in img_data.data_vars or 'hrf_est' in img_data.data_vars or 'group_average' in img_data.data_vars
+        if not has_data:
+            msg = f"Invalid image reconstruction data format. Variables found: {list(img_data.data_vars.keys())}, but none of 'Xs', 'hrf_est', or 'group_average' found."
+            print(f"ERROR: {msg}")
+            self.statbar.showMessage(msg)
+            return
+        
+        print("DEBUG: img_data is valid, extracting HRF data...")
+        # Extract the HRF estimate (try different variable names)
+        if 'Xs' in img_data.data_vars:
+            hrf_est = img_data['Xs']
+            print("DEBUG: Using 'Xs' variable (image reconstruction result)")
+        elif 'hrf_est' in img_data.data_vars:
+            hrf_est = img_data['hrf_est']
+            print("DEBUG: Using 'hrf_est' variable (individual subject data)")
+        elif 'group_average' in img_data.data_vars:
+            hrf_est = img_data['group_average']
+            print("DEBUG: Using 'group_average' variable (group average data)")
+        else:
+            error_msg = f"Invalid image reconstruction data format. Variables found: {list(img_data.data_vars.keys())}, but none of 'Xs', 'hrf_est', or 'group_average' found."
+            print(f"ERROR: {error_msg}")
+            QtWidgets.QMessageBox.critical(self, "Error", error_msg)
+            return
+            
+        print(f"Loaded image recon with dims: {hrf_est.dims}, shape: {hrf_est.shape}")
+        
+        # Determine if this is group average data
+        is_group_avg = 'group_average' in img_data.data_vars
+        print(f"DEBUG: is_group_avg={is_group_avg}")
+        
+        # Extract time bounds if time dimension exists
+        time_bounds = None
+        if 'time' in hrf_est.dims:
+            time_values = hrf_est.time.values
+            min_time = float(time_values.min())
+            max_time = float(time_values.max())
+            time_bounds = (min_time, max_time)
+            print(f"DEBUG: time_bounds={time_bounds}")
+        else:
+            print("DEBUG: No time dimension in data")
+        
+        # Get available trial types
+        if 'trial_type' in hrf_est.dims:
+            trial_types = [str(tt) for tt in hrf_est.trial_type.values]
+        else:
+            trial_types = [task_name]
+        
+        print(f"DEBUG: trial_types={trial_types}")
+        print("DEBUG: Creating ImageReconDialog...")
+        
+        # Create options dialog with group average flag and time bounds
+        dialog = ImageReconDialog(trial_types, is_group_avg=is_group_avg, 
+                                 time_bounds=time_bounds, parent=self)
+        
+        # Set up callback for when Launch Viewer is clicked
+        def launch_with_options(options):
+            print(f"User selected options: {options}")
+            self._perform_image_recon_launch(hrf_est, img_data, task_name, options, 
+                                            img_path, current_subject, is_group_avg)
+        
+        dialog.launch_callback = launch_with_options
+        print("DEBUG: Showing dialog...")
+        dialog.show()  # Non-modal, stays open
+    
+    def _perform_image_recon_launch(self, hrf_est, img_data, task_name, options, 
+                                    img_path, current_subject, is_group_avg):
+        """Perform the actual image reconstruction launch with the given options"""
+        print("DEBUG: Loading head model...")
+        # Load head model from config or default to icbm152
+        try:
+            import cedalion.dot as dot
+            
+            # Try to get head model from config
+            head_model = "icbm152"  # Default
+            if self.snakemake_config and 'image_recon' in self.snakemake_config:
+                config_head_model = self.snakemake_config['image_recon'].get('head_model', 'ICBM152')
+                head_model = config_head_model.lower()  # Convert to lowercase
+                print(f"DEBUG: Using head model from config: {config_head_model} -> {head_model}")
+            else:
+                print(f"DEBUG: No config found, using default: {head_model}")
+            
+            head = dot.get_standard_headmodel(head_model)
+            print(f"DEBUG: Successfully loaded {head_model} head model")
+        except Exception as e:
+            msg = f"Error loading head model: {str(e)}"
+            print(f"ERROR: {msg}")
+            import traceback
+            traceback.print_exc()
+            self.statbar.showMessage(msg)
+            return
+        
+        print("DEBUG: Preparing data for visualization...")
+        # Extract selected metric
+        metric = options.get('metric', 'mag')
+        print(f"DEBUG: Selected metric: {metric}")
+        
+        # Determine if this is group average data
+        is_group_avg = 'group_average' in img_data.data_vars
+        
+        # Prepare data based on selected metric
+        if metric == 'mag':
+            # Use HRF magnitude (already loaded as hrf_est)
+            data_to_viz = hrf_est
+            print(f"DEBUG: Using magnitude data")
+            
+        elif metric == 'std_err':
+            # Calculate standard error: sqrt(mse)
+            import numpy as np
+            if is_group_avg and 'total_stderr' in img_data.data_vars:
+                # Group average: sqrt(total_stderr)
+                data_to_viz = np.sqrt(img_data['total_stderr'])
+                print(f"DEBUG: Calculated std_err from total_stderr (group average)")
+            elif 'mse_t' in img_data.data_vars:
+                # Subject level: sqrt(mse_t)
+                data_to_viz = np.sqrt(img_data['mse_t'])
+                print(f"DEBUG: Calculated std_err from mse_t (subject level)")
+            else:
+                msg = "Cannot compute std_err: no mse data found"
+                print(f"ERROR: {msg}")
+                QtWidgets.QMessageBox.critical(self, "Error", msg)
+                return
+                
+        elif metric == 't_stat':
+            # T-statistic: mag / std_err
+            import numpy as np
+            if is_group_avg and 'tstat' in img_data.data_vars:
+                # Group average: use stored t-stat
+                data_to_viz = img_data['tstat']
+                print(f"DEBUG: Using stored tstat (group average)")
+            else:
+                # Subject level: calculate mag / std_err
+                if 'mse_t' in img_data.data_vars:
+                    std_err = np.sqrt(img_data['mse_t'])
+                    data_to_viz = hrf_est / std_err
+                    print(f"DEBUG: Calculated t_stat = mag / std_err (subject level)")
+                else:
+                    msg = "Cannot compute t_stat: no mse data found"
+                    print(f"ERROR: {msg}")
+                    QtWidgets.QMessageBox.critical(self, "Error", msg)
+                    return
+                    
+        elif metric == 'std_err_btwn_subjs':
+            # Between-subjects standard error (group only)
+            import numpy as np
+            if is_group_avg and 'mse_weighted_btwn_subjs' in img_data.data_vars:
+                data_to_viz = np.sqrt(img_data['mse_weighted_btwn_subjs'])
+                print(f"DEBUG: Calculated std_err_btwn_subjs from mse_weighted_btwn_subjs")
+            else:
+                msg = "std_err_btwn_subjs is only available for group average data"
+                print(f"ERROR: {msg}")
+                QtWidgets.QMessageBox.critical(self, "Error", msg)
+                return
+                
+        elif metric == 'std_err_within_subjs':
+            # Within-subjects standard error (group only)
+            import numpy as np
+            if is_group_avg and 'mse_mean_within_subj' in img_data.data_vars:
+                data_to_viz = np.sqrt(img_data['mse_mean_within_subj'])
+                print(f"DEBUG: Calculated std_err_within_subjs from mse_mean_within_subj")
+            else:
+                msg = "std_err_within_subjs is only available for group average data"
+                print(f"ERROR: {msg}")
+                QtWidgets.QMessageBox.critical(self, "Error", msg)
+                return
+        else:
+            msg = f"Unknown metric: {metric}"
+            print(f"ERROR: {msg}")
+            QtWidgets.QMessageBox.critical(self, "Error", msg)
+            return
+        
+        # Select the chosen trial_type
+        if 'trial_type' in data_to_viz.dims and len(data_to_viz.trial_type) > 0:
+            X_ts = data_to_viz.sel(trial_type=options['trial_type'])
+            print(f"DEBUG: Selected trial_type: {options['trial_type']}, new shape: {X_ts.shape}")
+        else:
+            X_ts = data_to_viz
+            print(f"DEBUG: No trial_type selection needed")
+        
+        # Transpose to expected format: (vertex, chromo, time)
+        expected_dims = ('vertex', 'chromo', 'time')
+        print(f"DEBUG: Current dims: {X_ts.dims}, expected: {expected_dims}")
+        if X_ts.dims != expected_dims:
+            try:
+                X_ts = X_ts.transpose(*expected_dims)
+                print(f"DEBUG: Transposed to dims: {X_ts.dims}")
+            except Exception as e:
+                print(f"WARNING: Could not transpose to {expected_dims}: {e}")
+        
+        # Handle time series data
+        SAVE = options['save']
+        mean_over_time = options.get('mean_over_time', False)
+        
+        if 'time' in X_ts.dims and X_ts.sizes['time'] > 1:
+            if not SAVE and not mean_over_time:
+                # Warn user that save option needs to be selected or mean over time
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Time Series Data",
+                    "Time series data detected. Please either:\n"
+                    "1. Enable 'Save output (PNG/GIF)' to create an animation, OR\n"
+                    "2. Enable 'Mean over time range' to display averaged data"
+                )
+                print("ERROR: Time series data requires either SAVE=True or mean_over_time=True")
+                self.statbar.showMessage("Please enable Save or Mean over time range for time series data")
+                return
+            elif mean_over_time and not SAVE:
+                # Compute mean over time range
+                import numpy as np
+                time_range = options.get('time_range')
+                if time_range:
+                    start_time, end_time, _ = time_range
+                    print(f"DEBUG: Computing mean over time range: {start_time} to {end_time}")
+                    # Select time slice
+                    X_ts = X_ts.sel(time=slice(start_time, end_time))
+                    print(f"DEBUG: Selected time range, shape: {X_ts.shape}")
+                else:
+                    print("DEBUG: Computing mean over all available time points")
+                
+                # Compute mean over time dimension
+                X_ts = X_ts.mean(dim='time')
+                print(f"DEBUG: Computed mean over time, new shape: {X_ts.shape}, dims: {X_ts.dims}")
+        
+        # Extract chromophore from view_type (e.g., "hbo_brain" -> "HbO")
+        view_type = options['view_type']
+        if 'hbo' in view_type:
+            chromo = 'HbO'
+        elif 'hbr' in view_type:
+            chromo = 'HbR'
+        else:
+            chromo = 'HbO'  # Default fallback
+        
+        # Calculate or use custom color limits
+        if options['clim'] is None:
+            print(f"DEBUG: Auto-calculating color limits for {chromo} and metric {metric}...")
+            import numpy as np
+            
+            # Check if metric should use symmetric or non-negative scaling
+            symmetric_metrics = ['mag', 't_stat']
+            if metric in symmetric_metrics:
+                # Symmetric color scale (e.g., -scl to +scl)
+                scl = np.percentile(np.abs(X_ts.sel(chromo=chromo)).values, 99)
+                clim = (-scl, scl)
+                print(f"DEBUG: Auto color limits for {chromo} (symmetric): {clim}")
+            else:
+                # Non-negative color scale for std_err types (0 to +scl)
+                scl = np.percentile(X_ts.sel(chromo=chromo).values, 99)
+                clim = (0, scl)
+                print(f"DEBUG: Auto color limits for {chromo} (non-negative): {clim}")
+        else:
+            clim = options['clim']
+            print(f"DEBUG: Using custom color limits: {clim}")
+        
+        # Prepare time range
+        time_range = options['time_range']
+        if SAVE:
+            # Construct structured save path
+            # Extract pkl basename without extension
+            pkl_basename = os.path.basename(img_path)
+            # Remove .pkl.gz or .pkl extension
+            if pkl_basename.endswith('.pkl.gz'):
+                pkl_basename = pkl_basename[:-7]  # Remove .pkl.gz
+            elif pkl_basename.endswith('.pkl'):
+                pkl_basename = pkl_basename[:-4]  # Remove .pkl
+            
+            # Build directory structure
+            plots_dir = os.path.join(self.path_to_data, 'plots', 'image_recon')
+            
+            if is_group_avg:
+                # Group: plots/image_recon/Xs_groupavg_task_timestamp/
+                save_dir = os.path.join(plots_dir, pkl_basename)
+            else:
+                # Subject: plots/image_recon/sub-XX/Xs_sub-XX_task_timestamp/
+                save_dir = os.path.join(plots_dir, current_subject, pkl_basename)
+            
+            # Create directory structure
+            os.makedirs(save_dir, exist_ok=True)
+            print(f"DEBUG: Created save directory: {save_dir}")
+            
+            # Prepend directory to user's filename
+            full_filename = os.path.join(save_dir, options['filename'])
+            print(f"DEBUG: Full save path: {full_filename}")
+            
+            # For animation, convert time range to units
+            try:
+                import pint
+                import pint_xarray
+                # Convert to units
+                time_range = (time_range[0], time_range[1], time_range[2]) * pint.Unit('second')
+                print(f"DEBUG: Time range with units: {time_range}")
+            except Exception as e:
+                print(f"WARNING: Could not create time range with units: {e}")
+                time_range = None
+        else:
+            # For static display, time_range is not used (either warned earlier or mean already computed)
+            full_filename = None
+            time_range = None
+            print("DEBUG: Static display mode - no save, time_range not used")
+        
+        # Launch the image reconstruction viewer
+        print(f"DEBUG: Launching {'multi-view' if options['multi_view'] else 'single-view'} mode...")
+        try:
+            # Determine title string
+            if options['title_str'] is not None:
+                title_str = options['title_str']
+                print(f"DEBUG: Using custom title: {title_str}")
+            else:
+                # Auto-generate title based on metric
+                metric_labels = {
+                    'mag': f'{chromo} / µM',
+                    'std_err': f'{chromo} std_err / µM',
+                    't_stat': f'{chromo} t-stat',
+                    'std_err_btwn_subjs': f'{chromo} std_err (between subjs) / µM',
+                    'std_err_within_subjs': f'{chromo} std_err (within subjs) / µM'
+                }
+                metric_label = metric_labels.get(metric, f'{chromo} {metric}')
+                title_str = f'{metric_label} - {task_name}'
+                if is_group_avg:
+                    title_str += ' (Group Average)'
+                print(f"DEBUG: Using auto-generated title: {title_str}")
+            
+            # Check if geo3d data is available
+            geo3d_plot = None
+            if options['show_geo3d'] and 'geo3d' in img_data.data_vars:
+                geo3d_plot = img_data['geo3d']
+                print("DEBUG: geo3d data available and will be plotted")
+            else:
+                print("DEBUG: No geo3d data or option disabled")
+            
+            if options['multi_view']:
+                # Multi-view mode: show all 6 views
+                from cedalion.vis.anatomy import image_recon_multi_view
+                
+                print(f"DEBUG: Calling image_recon_multi_view with:")
+                print(f"  - X_ts shape: {X_ts.shape}, dims: {X_ts.dims}")
+                print(f"  - view_type: {options['view_type']}")
+                print(f"  - cmap: {options['cmap']}")
+                print(f"  - clim: {clim}")
+                print(f"  - SAVE: {SAVE}")
+                print(f"  - fps: {options['fps']}")
+                print(f"  - wdw_size: {options['wdw_size']}")
+                print(f"  - geo3d_plot: {'Yes' if geo3d_plot is not None else 'No'}")
+                
+                # Show saving message
+                saving_msg = None
+                if SAVE:
+                    saving_msg = QtWidgets.QMessageBox(self)
+                    saving_msg.setWindowTitle("Saving")
+                    saving_msg.setText("Saving visualization, please wait...")
+                    saving_msg.setStandardButtons(QtWidgets.QMessageBox.NoButton)
+                    saving_msg.setModal(False)
+                    saving_msg.show()
+                    QtWidgets.QApplication.processEvents()  # Force UI update
+                
+                try:
+                    image_recon_multi_view(
+                        X_ts,
+                        head,
+                        cmap=options['cmap'],
+                        clim=clim,
+                        view_type=options['view_type'],
+                        title_str=title_str,
+                        filename=full_filename,
+                        SAVE=SAVE,
+                        time_range=time_range,
+                        fps=options['fps'],
+                        geo3d_plot=geo3d_plot,
+                        wdw_size=options['wdw_size']
+                    )
+                    print("DEBUG: image_recon_multi_view returned successfully!")
+                    
+                    if SAVE:
+                        self.statbar.showMessage(f"Saved to: {full_filename}")
+                finally:
+                    if saving_msg is not None:
+                        saving_msg.close()
+                        saving_msg.deleteLater()
+            else:
+                # Single-view mode: show one view at specified position
+                from cedalion.vis.anatomy import image_recon
+                
+                print(f"DEBUG: Calling image_recon with:")
+                print(f"  - X_ts shape: {X_ts.shape}, dims: {X_ts.dims}")
+                print(f"  - view_type: {options['view_type']}")
+                print(f"  - view_position: {options['view_position']}")
+                print(f"  - cmap: {options['cmap']}")
+                print(f"  - clim: {clim}")
+                print(f"  - wdw_size: {options['wdw_size']}")
+                print(f"  - geo3d_plot: {'Yes' if geo3d_plot is not None else 'No'}")
+                
+                # Show saving message if saving
+                saving_msg = None
+                if SAVE:
+                    saving_msg = QtWidgets.QMessageBox(self)
+                    saving_msg.setWindowTitle("Saving")
+                    saving_msg.setText("Saving visualization, please wait...")
+                    saving_msg.setStandardButtons(QtWidgets.QMessageBox.NoButton)
+                    saving_msg.setModal(False)
+                    saving_msg.show()
+                    QtWidgets.QApplication.processEvents()  # Force UI update
+                
+                try:
+                    # For single view
+                    p0, surf, lab = image_recon(
+                        X_ts,
+                        head,
+                        cmap=options['cmap'],
+                        clim=clim,
+                        view_type=options['view_type'],
+                        view_position=options['view_position'],
+                        title_str=title_str,
+                        off_screen=SAVE,  # Off-screen if saving
+                        show_scalar_bar=True,
+                        wdw_size=options['wdw_size']
+                    )
+                    
+                    # Add geo3d if available
+                    if geo3d_plot is not None:
+                        from cedalion.vis.blocks import plot_labeled_points
+                        plot_labeled_points(p0, geo3d_plot)
+                    
+                    # Save if requested
+                    if SAVE:
+                        p0.screenshot(full_filename + '.png')
+                        self.statbar.showMessage(f"Saved to: {full_filename}.png")
+                    else:
+                        p0.show()
+                    
+                    print("DEBUG: image_recon single-view completed successfully!")
+                finally:
+                    if saving_msg is not None:
+                        saving_msg.close()
+                        saving_msg.deleteLater()
+            
+            self.statbar.showMessage("Image reconstruction viewer launched")
+        except Exception as e:
+            print(f"ERROR: Exception launching image reconstruction viewer: {e}")
+            import traceback
+            traceback.print_exc()
+            self.statbar.showMessage(f"Error launching image recon: {str(e)}")
+
+    def _update_stim_types(self):
+        """Update available stimulus types from the current recording"""
+        if hasattr(self, 'snirfRec') and self.snirfRec is not None and len(self.snirfRec.stim) > 0:
+            self.available_stim_types = list(np.unique(self.snirfRec.stim.trial_type))
+            self.stim_button.setEnabled(True)
+            # Update button text to show selection count
+            self._update_stim_button_text()
+        else:
+            self.available_stim_types = []
+            self.stim_button.setEnabled(False)
+            self.stim_button.setText("No Stimuli")
+
+    def _update_stim_button_text(self):
+        """Update the button text to show current selection"""
+        if not self.selected_stim_types:
+            self.stim_button.setText("Select Stimuli")
+        elif len(self.selected_stim_types) == len(self.available_stim_types):
+            self.stim_button.setText("All Stimuli")
+        else:
+            self.stim_button.setText(f"Stimuli ({len(self.selected_stim_types)})")
+
+    def _open_stim_dialog(self):
+        """Open dialog for selecting stimuli"""
+        if not self.available_stim_types:
+            return
+            
+        dialog = QtWidgets.QDialog(self)
+        dialog.setWindowTitle("Select Stimuli")
+        dialog.setModal(True)
+        
+        layout = QtWidgets.QVBoxLayout()
+        
+        # Add "All" and "None" buttons
+        button_layout = QtWidgets.QHBoxLayout()
+        
+        all_button = QtWidgets.QPushButton("All")
+        none_button = QtWidgets.QPushButton("None")
+        
+        button_layout.addWidget(all_button)
+        button_layout.addWidget(none_button)
+        layout.addLayout(button_layout)
+        
+        # Create checkboxes for each stimulus type
+        self.stim_checkboxes = {}
+        for stim_type in self.available_stim_types:
+            # Check if this stimulus has HRF data
+            has_hrf = stim_type in self.hrf_available_stim_types
+            
+            # Create label with HRF indicator
+            if has_hrf:
+                label_text = f"{stim_type} (HRF available)"
+            else:
+                label_text = stim_type
+            
+            checkbox = QtWidgets.QCheckBox(label_text)
+            checkbox.setChecked(stim_type in self.selected_stim_types)
+            
+            # If HRF view is enabled, only enable checkboxes for stimuli with HRF data
+            if self.hrf_view.isChecked() and not has_hrf:
+                checkbox.setEnabled(False)
+                checkbox.setChecked(False)
+            
+            self.stim_checkboxes[stim_type] = checkbox
+            layout.addWidget(checkbox)
+        
+        # OK and Cancel buttons
+        button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        layout.addWidget(button_box)
+        
+        dialog.setLayout(layout)
+        
+        # Connect signals
+        all_button.clicked.connect(lambda: self._select_all_stims(True))
+        none_button.clicked.connect(lambda: self._select_all_stims(False))
+        button_box.accepted.connect(dialog.accept)
+        button_box.rejected.connect(dialog.reject)
+        
+        # Show dialog and update selection if accepted
+        if dialog.exec() == QtWidgets.QDialog.Accepted:
+            self.selected_stim_types = set()
+            for stim_type, checkbox in self.stim_checkboxes.items():
+                if checkbox.isChecked():
+                    self.selected_stim_types.add(stim_type)
+            
+            self._update_stim_button_text()
+            self._draw_timeseries()
+
+    def _select_all_stims(self, select_all):
+        """Select or deselect all stimulus checkboxes"""
+        for checkbox in self.stim_checkboxes.values():
+            checkbox.setChecked(select_all)
+        
+    def _subj_changed(self, s):
+        if not s or s == "None":
+            return
+
+        # 1. Store current run and optode selection
+        current_run = self.run.currentText()
+        
+        # 2. Get new subject and their available runs
+        new_subj = self.subj.currentText()
+        new_runs = self.subject_to_runs_map.get(new_subj, [])
+
+        # 3. Block signals from run box to prevent premature updates
+        self.run.blockSignals(True)
+        self.run.clear()
+
+        if new_runs:
+            self.run.addItems(new_runs)
+            
+            # Reapply colors to the new run items
+            self._reapply_run_colors(new_subj, new_runs)
+            
+            # 4. Try to restore the previous run selection
+            if current_run in new_runs:
+                self.run.setCurrentText(current_run)
+            else:
+                # Try to find a 'run-1' as a fallback
+                run1_fallback = next((r for r in new_runs if r.startswith("run-1")), None)
+                if run1_fallback:
+                    self.run.setCurrentText(run1_fallback)
+                # Otherwise, the first item is selected by default
+        else:
+            self.run.addItem("None")
+
+        # 5. Unblock signals and manually trigger the update
+        self.run.blockSignals(False)
+        self._run_changed(self.run.currentText(), subject_changed=True)
+        
+        # Update current selection colors
+        self._update_combobox_selection_colors()
+
+    def _run_changed(self, s, subject_changed=False):
+        if not s or s == "None":
+            return
+        
+        subj_key = self.subj.currentText()
+        self._update_recording_data(subj_key, s, subject_changed=subject_changed)
+        
+        # Update current selection colors
+        self._update_combobox_selection_colors()
+
+    def _update_run_box(self):
+        """(DEPRECATED) - This logic is now handled in _subj_changed."""
+        current_subj = self.subj.currentText()
+        self.run.clear()
+        
+        if current_subj in self.subject_to_runs_map:
+            available_runs = self.subject_to_runs_map[current_subj]
+            self.run.addItems(available_runs)
+        else:
+            self.run.addItem("None")
+
+    def _update_recording_data(self, subj_key, run_key, subject_changed=False):
+        """Loads the prepared data for a subject/run and updates the GUI."""
+        
+        new_prepared_data = self._get_recording(subj_key, run_key)
+
+        if new_prepared_data is None:
+            print(f"Data is None for Subject: {subj_key}, Run: {run_key}")
+            self._dataTimeSeries_ax.clear()
+            self._optode_ax.clear()
+            self.plots.figure.canvas.draw()
+            return
+
+        # Check if data is actually new
+        if self.snirfRec is new_prepared_data['snirfRec']:
+            return
+        
+        redraw_optodes = subject_changed
+
+        # --- Save previous selections ---
+        prev_ts = None
+        prev_wv = []
+        prev_selected = []
+        prev_selected_channels = []
+        prev_selected_stims = set()
+        if hasattr(self, 'ts') and self.ts.currentItem() is not None:
+            prev_ts = self.ts.currentItem().text()
+        if hasattr(self, 'wv'):
+            prev_wv = [item.text() for item in self.wv.selectedItems()]
+        prev_selected = list(self.selected) if hasattr(self, 'selected') else []
+        prev_selected_channels = list(self.selected_channels) if hasattr(self, 'selected_channels') else []
+        prev_selected_stims = set(self.selected_stim_types) if hasattr(self, 'selected_stim_types') else set()
+
+        # Unpack the prepared data into the main object
+        for key, value in new_prepared_data.items():
+            setattr(self, key, value)
+
+        print(f"Loaded data for Subject: {subj_key}, Run: {run_key}")
+        print(f"DEBUG: hrf_data available: {hasattr(self, 'hrf_data') and self.hrf_data is not None}")
+        
+        # Enable image recon button if we have data
+        self.image_recon_btn.setEnabled(True)
+        
+        self._init_widgets(redraw_optodes=redraw_optodes)
+        
+        # Show ready status
+        self.statbar.showMessage(f"✓ Ready: {subj_key}/{run_key}", 0)  # Keep until next change
+        QtWidgets.QApplication.processEvents()  # Force GUI update
+
+        # --- Restore previous selections ---
+        # Timeseries
+        if prev_ts and prev_ts in self.timeseries_keys:
+            idx = self.ts.findItems(prev_ts, QtCore.Qt.MatchExactly)
+            if idx:
+                self.ts.setCurrentItem(idx[0])
+        elif len(self.timeseries_keys) > 0:
+            # Default to first timeseries if no previous selection
+            self.ts.setCurrentRow(1)  # Row 1 since row 0 is "None"
+        # Wavelength/Concentration
+        if prev_wv:
+            for i in range(self.wv.count()):
+                item = self.wv.item(i)
+                if item.text() in prev_wv:
+                    item.setSelected(True)
+        # Channel selection (now unified approach)
+        if prev_selected_channels and max(prev_selected_channels) < self.no_channels:
+            self.selected_channels = prev_selected_channels
+        elif prev_selected and max(prev_selected) < len(self.opt_label):
+            # Convert old optode selection to channel selection for compatibility
+            self.selected_channels = []
+            for opt_idx in prev_selected:
+                opt_label = self.opt_label[opt_idx]
+                if "S" in opt_label:
+                    channels_to_add = self.snirfData.source[
+                        self.snirfData.source == opt_label
+                    ].channel.values.tolist()
+                elif "D" in opt_label:
+                    channels_to_add = self.snirfData.detector[
+                        self.snirfData.detector == opt_label
+                    ].channel.values.tolist()
+                else:
+                    channels_to_add = []
+                    
+                for chan in channels_to_add:
+                    chan_idx = np.where(self.snirfData.channel.values == chan)[0]
+                    if len(chan_idx) > 0:
+                        idx = chan_idx[0]
+                        if idx not in self.selected_channels:
+                            self.selected_channels.append(idx)
+        elif len(self.opt_label) > 0:
+            # Default: select channels from first optode
+            opt_label = self.opt_label[0]
+            self.selected_channels = []
+            if "S" in opt_label:
+                channels_to_add = self.snirfData.source[
+                    self.snirfData.source == opt_label
+                ].channel.values.tolist()
+            elif "D" in opt_label:
+                channels_to_add = self.snirfData.detector[
+                    self.snirfData.detector == opt_label
+                ].channel.values.tolist()
+            else:
+                channels_to_add = []
+                
+            for chan in channels_to_add:
+                chan_idx = np.where(self.snirfData.channel.values == chan)[0]
+                if len(chan_idx) > 0:
+                    self.selected_channels.append(chan_idx[0])
+        
+        # Clear old optode selection - we now use unified channel selection
+        self.selected = []
+        
+        # Restore stimulus selection (only keep stimuli that exist in new data)
+        if prev_selected_stims and hasattr(self, 'available_stim_types'):
+            self.selected_stim_types = prev_selected_stims.intersection(set(self.available_stim_types))
+            self._update_stim_button_text()
+
+        self._draw_timeseries()
+
+    def _wv_changed(self):
+        self._draw_timeseries()
+
+    def _ts_changed(self, s):
+        # Extract data
+        if s == "None":
+            self.snirfData = None
+            self._dataTimeSeries_ax.clear()
+            return
+
+        # Check if we have processed data with this timeseries
+        if s != 'amp' and self.processed_rec and hasattr(self.processed_rec, 'timeseries') and s in self.processed_rec.timeseries:
+            self.snirfData = self.processed_rec.timeseries[s]
+        else:
+            # Use amplitude data from SNIRF
+            self.snirfData = self.snirfRec.timeseries[s]
+        
+        self.ts_sel = s
+
+        # Determine wavelength/concentration
+        if "wavelength" in self.snirfData.dims:
+            self.wv_label.setText("Wavelength:")
+            self.wv.clear()
+
+            for i_w, wvl in enumerate(self.snirfData.wavelength.values):
+                self.wv.insertItem(i_w, str(wvl))
+            self.wv.setCurrentRow(0)
+
+        elif "chromo" in self.snirfData.dims:
+            self.wv_label.setText("Concentration:")
+            self.wv.clear()
+
+            for i_w, wvl in enumerate(self.snirfData.chromo.values):
+                self.wv.insertItem(i_w, f"[{str(wvl)}]")
+            self.wv.setCurrentRow(0)
+
+        self._draw_timeseries()
+
+    def _update_channel_highlights(self):
+        """Update the channel line highlighting on the probe display"""
+        # Color palette
+        chan_col = [
+            "#FF0000", "#0000FF", "#00FF00", "#FF00FF", "#FFFF00", "#00FFFF", "#FF8000", "#8000FF",
+            "#FF0080", "#00FF80", "#0080FF", "#FF6B6B", "#4ECDC4", "#FFB000", "#117733", "#DC267F",
+            "#332288", "#882255", "#44AA99", "#88CCEE", "#DDCC77", "#CC6677", "#AA4499", "#45B7D1",
+            "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8", "#F7DC6F", "#BB8FCE", "#85C1E9", "#F8C471"
+        ]
+        
+        # Reset all channel lines to default first
+        for line in self.channel_lines:
+            line.set_color([0.8, 0.8, 0.8])
+            line.set_linewidth(2)
+            
+        # Highlight selected channels
+        for i, chan_idx in enumerate(self.selected_channels):
+            if chan_idx < len(self.channel_lines):
+                # Use a smart color assignment to avoid conflicts with nearby channels
+                # If we have fewer selected channels than colors, use sequential assignment
+                if len(self.selected_channels) <= len(chan_col):
+                    color_idx = i
+                else:
+                    # For many channels, use the channel index with better distribution
+                    color_idx = chan_idx % len(chan_col)
+                
+                self.channel_lines[chan_idx].set_color(chan_col[color_idx])
+                self.channel_lines[chan_idx].set_linewidth(3)
+                    
+        self._optode_ax.figure.canvas.draw()
+
+    def _draw_timeseries(self):
+
+        xxlim = self._dataTimeSeries_ax.get_xlim()
+
+        self._dataTimeSeries_ax.clear()
+
+        if self.snirfData is None:
+            return
+        if len(self.selected_channels) == 0:
+            return
+
+        # Check if HRF view is enabled
+        if self.hrf_view.isChecked() and hasattr(self, 'hrf_data') and self.hrf_data is not None:
+            # Don't pass xxlim to HRF view since time scales are very different
+            self._draw_hrf_timeseries()
+            return
+
+        # Extract time information
+        self.t = self.snirfData.time.values
+        
+        # Check if we need to reset xlim (e.g., switching from HRF view or initial load)
+        # If the saved xlim is outside the time series data range, reset it
+        if xxlim[1] < self.t[-1] * 0.5 or xxlim[0] < 0 or xxlim[1] > self.t[-1]:
+            xxlim = (0, 1)  # This will trigger auto-scaling later
+
+        # Use unified channel selection - convert indices to channel names
+        chan_sel = [self.snirfData.channel.values[i] for i in self.selected_channels 
+                   if i < len(self.snirfData.channel.values)]
+        chan_sel = np.unique(chan_sel)
+
+        ## Grab coordinates
+        nempty_chan_sel = []
+        x_chan_sel = [[], []]
+        y_chan_sel = [[], []]
+
+        for chan in chan_sel:
+            if not np.isnan(self.snirfData.sel(channel=chan)[0][0]):
+                x_chan_sel[0].append(
+                    self.sx[
+                        self.slabel == self.snirfData.sel(channel=chan).source.values
+                    ][0]
+                )
+                x_chan_sel[1].append(
+                    self.dx[
+                        self.dlabel == self.snirfData.sel(channel=chan).detector.values
+                    ][0]
+                )
+                y_chan_sel[0].append(
+                    self.sy[
+                        self.slabel == self.snirfData.sel(channel=chan).source.values
+                    ][0]
+                )
+                y_chan_sel[1].append(
+                    self.dy[
+                        self.dlabel == self.snirfData.sel(channel=chan).detector.values
+                    ][0]
+                )
+                nempty_chan_sel.append(chan)
+
+        wvl_idx = self.wv.selectedItems()
+        wvl_idx = [foo.text() for foo in wvl_idx]
+        wvl_ls = ["-", ":"]
+
+        ## Grab timeseries y-label
+        ylabel = self.ts_sel
+        if "amp" in ylabel:
+            ylabel = "amp (A.U.)"
+        elif "od" in ylabel:
+            ylabel = r"$\Delta$ OD (A.U.)"
+        elif "conc" in ylabel or "chromo" in self.snirfData.dims:
+            ylabel = r"$\Delta$ Concentration ($\mu$M)"
+
+        # Update channel highlighting on probe display
+        self._update_channel_highlights()
+        
+        # Color palette for time series plots - ordered from high contrast to low contrast
+        chan_col = [
+            "#FF0000", "#0000FF", "#00FF00", "#FF00FF", "#FFFF00", "#00FFFF", "#FF8000", "#8000FF",
+            "#FF0080", "#00FF80", "#0080FF", "#FF6B6B", "#4ECDC4", "#FFB000", "#117733", "#DC267F",
+            "#332288", "#882255", "#44AA99", "#88CCEE", "#DDCC77", "#CC6677", "#AA4499", "#45B7D1",
+            "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8", "#F7DC6F", "#BB8FCE", "#85C1E9", "#F8C471"
+        ]
+
+        # Clean up existing channel highlights
+        for item in self.chan_highlight:
+            if hasattr(item, 'remove'):  # Check if it's actually a line object
+                try:
+                    item.remove()
+                except:
+                    pass
+
+        self.chan_highlight = []
+
+
+        # Plot lines of aux
+        if len(self.aux_sel):
+            self.auxplot = self._auxTimeSeries_ax.plot(
+                self.aux_sel.time,
+                self.aux_sel,
+                zorder=2,
+                color="r",
+                alpha=0.3,
+                linewidth=0.5,
+            )  # Always a list
+        else:
+            self.auxplot = []
+        # self.auxplot is always a list now
+
+        self._auxTimeSeries_ax.set_ylabel(self.aux_type, rotation=270, ha="right")
+        self._auxTimeSeries_ax.yaxis.set_label_position("right")
+        self._auxTimeSeries_ax.figure.canvas.draw()
+
+        ymin = 100
+        ymax = -100
+
+        # Plot timeseries
+        if "wavelength" in self.snirfData.dims:
+            for sel_wv in wvl_idx:
+                idx = self.snirfData.wavelength.values
+                idx = [str(foo) for foo in idx]
+                idx = idx.index(sel_wv)
+                for i_ch, chan in enumerate(nempty_chan_sel):
+                    # Get the actual channel index for consistent coloring
+                    chan_idx = np.where(self.snirfData.channel.values == chan)[0][0]
+                    
+                    # Use smart color assignment to avoid conflicts
+                    if len(self.selected_channels) <= len(chan_col):
+                        # Find position of this channel in selected channels
+                        color_idx = self.selected_channels.index(chan_idx) if chan_idx in self.selected_channels else i_ch
+                    else:
+                        color_idx = chan_idx % len(chan_col)
+                    
+                    self.timeSeries = self._dataTimeSeries_ax.plot(
+                        self.t,
+                        self.snirfData.sel(channel=chan, wavelength=sel_wv).T,
+                        ls=wvl_ls[idx],
+                        zorder=5,
+                        color=chan_col[color_idx],
+                    )
+
+                    ymin = min(
+                        ymin,
+                        min(
+                            self.snirfData.sel(
+                                channel=chan, wavelength=sel_wv
+                            ).values.ravel()
+                        ),
+                    )
+                    ymax = max(
+                        ymax,
+                        max(
+                            self.snirfData.sel(
+                                channel=chan, wavelength=sel_wv
+                            ).values.ravel()
+                        ),
+                    )
+
+        elif "chromo" in self.snirfData.dims:
+            for sel_wv in wvl_idx:
+                idx = self.snirfData.chromo.values
+                idx = [str(foo) for foo in idx]
+                idx = idx.index(sel_wv[1:-1])
+
+                if "[" in sel_wv:
+                    sel_wv = sel_wv[1:-1]
+
+                for i_ch, chan in enumerate(nempty_chan_sel):
+                    # Get the actual channel index for consistent coloring
+                    chan_idx = np.where(self.snirfData.channel.values == chan)[0][0]
+                    
+                    # Use smart color assignment to avoid conflicts
+                    if len(self.selected_channels) <= len(chan_col):
+                        # Find position of this channel in selected channels
+                        color_idx = self.selected_channels.index(chan_idx) if chan_idx in self.selected_channels else i_ch
+                    else:
+                        color_idx = chan_idx % len(chan_col)
+                    
+                    self.timeSeries = self._dataTimeSeries_ax.plot(
+                        self.t,
+                        self.snirfData.sel(channel=chan, chromo=sel_wv).T,
+                        ls=wvl_ls[idx],
+                        zorder=5,
+                        color=chan_col[color_idx],
+                    )
+
+                    ymin = min(
+                        ymin,
+                        min(
+                            self.snirfData.sel(
+                                channel=chan, chromo=sel_wv
+                            ).values.ravel()
+                        ),
+                    )
+                    ymax = max(
+                        ymax,
+                        max(
+                            self.snirfData.sel(
+                                channel=chan, chromo=sel_wv
+                            ).values.ravel()
+                        ),
+                    )
+
+        # Plot stims
+        stim_col = ["#648FFF", "#DC267F", "#FFB000", "#785EF0", "#FE6100"]
+        if self.selected_stim_types and hasattr(self, 'snirfRec') and len(self.snirfRec.stim) > 0:
+            ymax = ymax + (0.05 * (ymax - ymin))
+            ymin = ymin - (0.05 * (ymax - ymin))
+
+            # Only plot selected stimulus types
+            all_stim_types = np.unique(self.snirfRec.stim.trial_type)
+            selected_types = [tt for tt in all_stim_types if tt in self.selected_stim_types]
+            
+            for i_t, tt in enumerate(selected_types):
+                label_on = True
+                for i_r, dat in self.snirfRec.stim.loc[
+                    self.snirfRec.stim["trial_type"] == tt
+                ].iterrows():
+                    if label_on:
+                        self._dataTimeSeries_ax.axvline(
+                            dat.onset,
+                            ls="--",
+                            lw=1,
+                            zorder=1,
+                            c=stim_col[i_t % 5],
+                            label=tt,
+                        )
+                        self._dataTimeSeries_ax.fill(
+                            [
+                                dat.onset,
+                                dat.onset,
+                                dat.onset + dat.duration,
+                                dat.onset + dat.duration,
+                            ],
+                            [ymin, ymax, ymax, ymin],
+                            color=stim_col[i_t % 5] + "22",
+                            zorder=1,
+                        )
+                    else:
+                        self._dataTimeSeries_ax.axvline(
+                            dat.onset, ls="--", lw=1, zorder=1, c=stim_col[i_t % 5]
+                        )
+                        self._dataTimeSeries_ax.fill(
+                            [
+                                dat.onset,
+                                dat.onset,
+                                dat.onset + dat.duration,
+                                dat.onset + dat.duration,
+                            ],
+                            [ymin, ymax, ymax, ymin],
+                            color=stim_col[i_t % 5] + "22",
+                            zorder=1,
+                        )
+
+                    label_on = False
+
+            self._dataTimeSeries_ax.legend(loc="upper right")
+
+        self._dataTimeSeries_ax.set_ylabel(ylabel)
+        self._dataTimeSeries_ax.grid("True", axis="y")
+
+        # set the xlim if desired
+        if xxlim[0] != 0 and xxlim[1] != 1:
+            self._dataTimeSeries_ax.set_xlim(xxlim)
+
+        self._dataTimeSeries_ax.figure.canvas.draw()
+
+        self.statbar.showMessage("Timeseries Drawn!")
+
+    def _draw_hrf_timeseries(self):
+        """Draw HRF estimates instead of time series"""
+        
+        print(f"_draw_hrf_timeseries called. Group avg checkbox state: {self.hrf_group_avg.isChecked()}")
+        
+        # Update channel highlighting on probe display
+        self._update_channel_highlights()
+        
+        # Check if group average is selected
+        if self.hrf_group_avg.isChecked():
+            # Load group average HRF data
+            print("Attempting to load group average HRF data...")
+            hrf_data = self._load_group_average_hrf()
+            print(f"Load result: {hrf_data is not None}")
+            if hrf_data is None:
+                print("Group average HRF data is None - returning early")
+                self.statbar.showMessage("No group average HRF data found")
+                self._dataTimeSeries_ax.figure.canvas.draw()
+                return
+            
+            # Extract the actual xarray DataArray from the loaded data
+            if isinstance(hrf_data, dict):
+                print(f"Loaded data is a dict with keys: {hrf_data.keys()}")
+                # Try common keys where the HRF data might be stored
+                hrf_est = hrf_data.get('hrf_est') or hrf_data.get('groupaverage') or hrf_data.get('data')
+                if hrf_est is None:
+                    # If still None, look for the first xarray object in the dict
+                    for key, value in hrf_data.items():
+                        if hasattr(value, 'dims'):
+                            hrf_est = value
+                            print(f"Found xarray data in key: {key}")
+                            break
+            else:
+                # If it's an xarray Dataset, try to extract the data variable
+                if hasattr(hrf_data, 'data_vars'):
+                    # It's an xarray Dataset, extract the data variable
+                    print(f"Data is an xarray Dataset with variables: {list(hrf_data.data_vars.keys())}")
+                    # Try common variable names
+                    if 'hrf_est' in hrf_data.data_vars:
+                        hrf_est = hrf_data['hrf_est']
+                    elif 'group_average' in hrf_data.data_vars:
+                        hrf_est = hrf_data['group_average']
+                    elif 'hrf_estimate' in hrf_data.data_vars:
+                        hrf_est = hrf_data['hrf_estimate']
+                    else:
+                        # Use the first data variable
+                        first_var = list(hrf_data.data_vars.keys())[0]
+                        hrf_est = hrf_data[first_var]
+                        print(f"Using first data variable: {first_var}")
+                else:
+                    # It's already a DataArray
+                    hrf_est = hrf_data
+            
+            if hrf_est is None or not hasattr(hrf_est, 'dims'):
+                print(f"Could not find valid HRF data. Type: {type(hrf_data)}")
+                self.statbar.showMessage("Invalid group average HRF data format")
+                self._dataTimeSeries_ax.figure.canvas.draw()
+                return
+            
+            print(f"Group average HRF loaded. Dimensions: {hrf_est.dims}")
+            print(f"Trial types: {hrf_est.coords['trial_type'].values}")
+            print(f"Chromophores: {hrf_est.coords['chromo'].values}")
+            # For group average, use selected channels if any are selected
+            if hasattr(self, 'selected_channels') and len(self.selected_channels) > 0:
+                chan_sel = [self.snirfData.channel.values[i] for i in self.selected_channels 
+                           if i < len(self.snirfData.channel.values)]
+                chan_sel = np.unique(chan_sel)
+                print(f"Using {len(chan_sel)} selected channels for group average")
+            else:
+                chan_sel = None
+                print("Using all channels for group average")
+        else:
+            # Get HRF data from current subject/run
+            if not hasattr(self, 'hrf_data') or self.hrf_data is None:
+                self.statbar.showMessage("No HRF data loaded for current recording")
+                return
+            hrf_est = self.hrf_data.get('hrf_est')
+            if hrf_est is None:
+                self.statbar.showMessage("No HRF estimates found in data")
+                return
+            
+            # For individual data, use selected channels
+            chan_sel = [self.snirfData.channel.values[i] for i in self.selected_channels 
+                       if i < len(self.snirfData.channel.values)]
+            chan_sel = np.unique(chan_sel)
+            
+            if len(chan_sel) == 0:
+                self.statbar.showMessage("No channels selected")
+                self._dataTimeSeries_ax.figure.canvas.draw()
+                return
+        
+        # Get time vector from HRF data
+        hrf_time = hrf_est.coords['time'].values
+        
+        # Color palette (same as time series) - ordered from high contrast to low contrast
+        chan_col = [
+            "#FF0000", "#0000FF", "#00FF00", "#FF00FF", "#FFFF00", "#00FFFF", "#FF8000", "#8000FF",
+            "#FF0080", "#00FF80", "#0080FF", "#FF6B6B", "#4ECDC4", "#FFB000", "#117733", "#DC267F",
+            "#332288", "#882255", "#44AA99", "#88CCEE", "#DDCC77", "#CC6677", "#AA4499", "#45B7D1",
+            "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8", "#F7DC6F", "#BB8FCE", "#85C1E9", "#F8C471"
+        ]
+        
+        # Get selected wavelength/chromo
+        wvl_idx = self.wv.selectedItems()
+        wvl_idx = [foo.text() for foo in wvl_idx]
+        wvl_ls = ["-", ":"]
+        
+        # Get trial types from HRF data
+        trial_types = hrf_est.coords['trial_type'].values
+        
+        # Filter trial types based on selected stimulus types
+        # If no stimuli are selected, don't display any HRF
+        if not self.selected_stim_types:
+            self.statbar.showMessage("No stimuli selected for HRF display")
+            self._dataTimeSeries_ax.figure.canvas.draw()
+            return
+            
+        trial_types = [tt for tt in trial_types if tt in self.selected_stim_types]
+        
+        if len(trial_types) == 0:
+            self.statbar.showMessage("No HRF data available for selected stimuli")
+            self._dataTimeSeries_ax.figure.canvas.draw()
+            return
+        
+        # Get available chromophores from HRF data
+        available_chromos = list(hrf_est.coords['chromo'].values)
+        
+        # Filter chromophores based on checkbox selections
+        selected_chromos = []
+        if self.hrf_hbo.isChecked() and 'HbO' in available_chromos:
+            selected_chromos.append('HbO')
+        if self.hrf_hbr.isChecked() and 'HbR' in available_chromos:
+            selected_chromos.append('HbR')
+        
+        # If no chromophores selected, show message and return
+        if not selected_chromos:
+            self.statbar.showMessage("No chromophores selected for HRF display")
+            self._dataTimeSeries_ax.figure.canvas.draw()
+            return
+        
+        print(f"Plotting HRF - Trial types: {trial_types}, Chromos: {selected_chromos}, Group avg: {self.hrf_group_avg.isChecked()}")
+        
+        ymin = 100
+        ymax = -100
+        
+        # Define line styles for different stimuli (trial types)
+        stim_line_styles = ['-', '--', '-.', ':']  # solid, dashed, dash-dot, dotted
+        
+        # Define markers for different stimuli (optional, adds more distinction)
+        stim_markers = ['', '', '', '']  # No markers by default, or use: ['o', 's', '^', 'v']
+        
+        # Plot HRF for each selected channel and trial type
+        if 'chromo' in hrf_est.dims:
+            if self.hrf_group_avg.isChecked():
+                # For group average: plot individual lines for each selected channel
+                print(f"Group average plotting mode. Trial types to plot: {trial_types}")
+                
+                # Determine which channels to plot
+                if chan_sel is not None and len(chan_sel) > 0:
+                    channels_to_plot = chan_sel
+                    print(f"Plotting {len(channels_to_plot)} selected channels")
+                else:
+                    # If no channels selected, plot all channels
+                    channels_to_plot = hrf_est.coords['channel'].values
+                    print(f"No channels selected, plotting all {len(channels_to_plot)} channels")
+                
+                num_plots = 0
+                for i_chan, channel in enumerate(channels_to_plot):
+                    # Use channel-specific color
+                    chan_color = chan_col[i_chan % len(chan_col)]
+                    
+                    for i_tt, trial_type in enumerate(trial_types):
+                        # Get line style for this stimulus type
+                        line_style = stim_line_styles[i_tt % len(stim_line_styles)]
+                        marker = stim_markers[i_tt % len(stim_markers)]
+                        
+                        for chromo_name in selected_chromos:
+                            try:
+                                # Extract HRF data for this channel, trial type, and chromo
+                                hrf_values = hrf_est.sel(channel=channel, trial_type=trial_type, chromo=chromo_name).values
+                                
+                                # Set style based on chromophore
+                                if chromo_name == 'HbO':
+                                    linewidth = 2.5  # Thicker for HbO
+                                    alpha = 0.9      # More opaque
+                                    marker_style = ''  # No marker for HbO
+                                    marker_size = 0
+                                else:  # HbR
+                                    linewidth = 1.5  # Thinner for HbR
+                                    alpha = 0.8      # Slightly more transparent
+                                    marker_style = 'o' if marker else ''  # Add small markers for HbR
+                                    marker_size = 3
+                                
+                                # Plot with label showing channel, trial type and chromo
+                                label = f"{chromo_name}-{trial_type}-{channel}"
+                                self._dataTimeSeries_ax.plot(
+                                    hrf_time,
+                                    hrf_values,
+                                    ls=line_style,
+                                    marker=marker_style,
+                                    markersize=marker_size,
+                                    markevery=5,  # Only show markers every 5 points to avoid clutter
+                                    linewidth=linewidth,
+                                    zorder=5,
+                                    color=chan_color,
+                                    alpha=alpha,
+                                    label=label
+                                )
+                                num_plots += 1
+                                
+                                ymin = min(ymin, np.nanmin(hrf_values))
+                                ymax = max(ymax, np.nanmax(hrf_values))
+                            except (KeyError, ValueError) as e:
+                                print(f"Error plotting group average for channel {channel}, {trial_type}, {chromo_name}: {e}")
+                                continue
+                print(f"Total plots created: {num_plots}")
+            else:
+                # For individual data: plot each channel separately
+                for i_ch, chan in enumerate(chan_sel):
+                    # Get the actual channel index for consistent coloring with probe plot
+                    chan_idx = np.where(self.snirfData.channel.values == chan)[0][0]
+                    
+                    # Use smart color assignment (same logic as time series plotting)
+                    if len(self.selected_channels) <= len(chan_col):
+                        # Find position of this channel in selected channels
+                        color_idx = self.selected_channels.index(chan_idx) if chan_idx in self.selected_channels else i_ch
+                    else:
+                        color_idx = chan_idx % len(chan_col)
+                    
+                    # Get the channel color (same as in probe plot)
+                    channel_color = chan_col[color_idx]
+                    
+                    for i_tt, trial_type in enumerate(trial_types):
+                        # Get line style for this stimulus type
+                        line_style = stim_line_styles[i_tt % len(stim_line_styles)]
+                        marker = stim_markers[i_tt % len(stim_markers)]
+                        
+                        for chromo_name in selected_chromos:
+                            try:
+                                # Extract HRF data for this channel, trial type, and chromo
+                                hrf_values = hrf_est.sel(trial_type=trial_type, channel=chan, chromo=chromo_name).values
+                                
+                                # Set style based on chromophore
+                                if chromo_name == 'HbO':
+                                    linewidth = 2.5  # Thicker for HbO
+                                    alpha = 0.9      # More opaque
+                                    marker_style = ''  # No marker for HbO
+                                    marker_size = 0
+                                else:  # HbR
+                                    linewidth = 1.5  # Thinner for HbR
+                                    alpha = 0.8      # Slightly more transparent
+                                    marker_style = 'o' if marker else ''  # Add small markers for HbR
+                                    marker_size = 3
+                                
+                                # Plot with label showing channel, trial type, and chromo
+                                label = f"{chan}-{chromo_name}-{trial_type}"
+                                self._dataTimeSeries_ax.plot(
+                                    hrf_time,
+                                    hrf_values,
+                                    ls=line_style,
+                                    marker=marker_style,
+                                    markersize=marker_size,
+                                    markevery=5,  # Only show markers every 5 points to avoid clutter
+                                    linewidth=linewidth,
+                                    zorder=5,
+                                    color=channel_color,
+                                    alpha=alpha,
+                                    label=label
+                                )
+                                
+                                ymin = min(ymin, np.nanmin(hrf_values))
+                                ymax = max(ymax, np.nanmax(hrf_values))
+                            except (KeyError, ValueError) as e:
+                                continue
+        
+        # Set labels and formatting
+        self._dataTimeSeries_ax.set_xlabel("Time (s)")
+        self._dataTimeSeries_ax.set_ylabel(r"HRF Amplitude ($\Delta$ Concentration $\mu$M)")
+        self._dataTimeSeries_ax.grid(True, axis="y")
+        self._dataTimeSeries_ax.legend(loc="upper right")
+        
+        # Auto-scale to HRF time range (don't use time series xlim)
+        self._dataTimeSeries_ax.set_xlim(hrf_time[0], hrf_time[-1])
+        
+        self._dataTimeSeries_ax.figure.canvas.draw()
+        self.statbar.showMessage("HRF Drawn!")
+
+    def _aux_changed(self, s):  # TODO
+        self._auxTimeSeries_ax.clear()
+
+        if s == "None" or s == "dark signal":
+            self.aux_sel = []
+            self.aux_type = None
+            # Remove all auxplot lines if any
+            if hasattr(self, 'auxplot') and self.auxplot:
+                for line in self.auxplot:
+                    try:
+                        line.remove()
+                    except Exception:
+                        pass
+                self.auxplot = []
+        # elif s == 'dark signal':
+        #     return
+        else:
+            self.aux_sel = self.snirfRec.aux_ts[s]
+            self.aux_type = s
+
+        self._draw_timeseries()
+
+    # ============== Pipeline Monitoring Methods ==============
+    
+    def _find_snakemake_process_pid(self):
+        """Find the PID of the snakemake process using our config file"""
+        try:
+            import psutil
+            # Use the actual config path that was used (temp config or original)
+            config_to_search = getattr(self, '_actual_config_used', self.snakemake_config_path)
+            config_path = os.path.abspath(config_to_search)
+            # Normalize to forward slashes for comparison (Windows command lines often mix slashes)
+            config_path_normalized = config_path.replace('\\', '/')
+            
+            print(f"DEBUG PID search: Looking for config path: {config_path_normalized}")
+            
+            snakemake_procs = []
+            for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
+                try:
+                    cmdline = proc.info.get('cmdline', [])
+                    if not cmdline:
+                        continue
+                    
+                    cmdline_str = ' '.join(cmdline).lower()
+                    
+                    # Look for snakemake in command line (could be python snakemake or snakemake.exe)
+                    if 'snakemake' in cmdline_str:
+                        # Check if our config file is in the command
+                        cmdline_full = ' '.join(cmdline)
+                        snakemake_procs.append((proc.info['pid'], cmdline_full))
+                        
+                        # Normalize cmdline to forward slashes for comparison (handles mixed slashes)
+                        cmdline_normalized = cmdline_full.replace('\\', '/')
+                        
+                        # Check if our normalized config path is in normalized cmdline
+                        if config_path_normalized in cmdline_normalized:
+                            print(f"DEBUG PID search: ✓ Config path MATCHED! PID={proc.info['pid']}")
+                            return proc.info['pid']
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+            
+            print(f"DEBUG PID search: Found {len(snakemake_procs)} snakemake processes but none matched config")
+            if snakemake_procs:
+                print(f"DEBUG PID search: First snakemake command: {snakemake_procs[0][1][:300]}")
+            return None
+        except Exception as e:
+            print(f"Error finding snakemake process: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            return None
+    
+    def _store_pipeline_process_info(self, pid):
+        """Store process ID and start time in pipeline_status"""
+        try:
+            import psutil
+            proc = psutil.Process(pid)
+            
+            # Store PID and process creation time
+            self.pipeline_status['process_pid'] = pid
+            self.pipeline_status['process_start_time'] = proc.create_time()
+            
+            print(f"DEBUG: Stored pipeline process info - PID={pid}, start_time={proc.create_time()}")
+            
+            # Save to homer.config immediately
+            derivatives_dir = os.path.dirname(self.snakemake_config_path)
+            self._save_homer_config(
+                self.snakefile_path,
+                self.snakemake_config_path,
+                derivatives_dir,
+                self.pipeline_status
+            )
+        except Exception as e:
+            print(f"Error storing process info: {str(e)}")
+    
+    def _extract_all_tasks_and_runs_from_gui(self):
+        """Extract all unique tasks and run numbers from subject_to_runs_map"""
+        import re
+        all_tasks = set()
+        all_runs = set()
+        
+        for subject, runs in self.subject_to_runs_map.items():
+            for run_str in runs:
+                # Parse "task-STS_run-01" format
+                match = re.search(r'task-(\w+)_run-(\d+)', run_str)
+                if match:
+                    all_tasks.add(match.group(1))  # "STS"
+                    all_runs.add(match.group(2))    # "01"
+        
+        return sorted(all_tasks), sorted(all_runs)
+    
+    def _create_full_scope_temp_config(self):
+        """Create temporary config with all subjects, tasks, runs from GUI data
+        
+        Returns path to temporary config file, or None if creation fails
+        """
+        import tempfile
+        import copy
+        
+        try:
+            if not self.snakemake_config:
+                print("No snakemake_config loaded, cannot create full scope config")
+                return None
+            
+            # Extract all tasks and runs from GUI data
+            all_tasks, all_runs = self._extract_all_tasks_and_runs_from_gui()
+            
+            # Get subjects that have at least one run
+            subjects_with_runs = [s for s in self.subjects if self.subject_to_runs_map.get(s)]
+            
+            if not subjects_with_runs or not all_tasks or not all_runs:
+                print(f"Cannot create full scope config: subjects={len(subjects_with_runs)}, tasks={len(all_tasks)}, runs={len(all_runs)}")
+                return None
+            
+            print(f"Creating full scope config: {len(subjects_with_runs)} subjects, {len(all_tasks)} tasks, {len(all_runs)} runs")
+            print(f"  Subjects: {subjects_with_runs}")
+            print(f"  Tasks: {all_tasks}")
+            print(f"  Runs: {all_runs}")
+            
+            # Create a deep copy of the current config
+            full_config = copy.deepcopy(self.snakemake_config)
+            
+            # Update dataset section with all subjects/tasks/runs
+            if 'dataset' not in full_config:
+                full_config['dataset'] = {}
+            
+            full_config['dataset']['subject'] = subjects_with_runs
+            full_config['dataset']['task'] = all_tasks
+            full_config['dataset']['run'] = all_runs
+            
+            # Write to temporary file
+            temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False)
+            yaml.dump(full_config, temp_file, default_flow_style=False)
+            temp_file.close()
+            
+            print(f"Full scope temp config created: {temp_file.name}")
+            return temp_file.name
+            
+        except Exception as e:
+            print(f"Error creating full scope temp config: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            return None
+    
+    def _load_file_status_maps(self):
+        """Load both current scope and full scope file status maps from summary
+        
+        This runs two summary commands:
+        1. With current user config (filtered subjects/tasks/runs)
+        2. With full scope config (all subjects/tasks/runs from GUI)
+        """
+        print("\n=== Loading file status maps ===")
+        
+        if not self.snakefile_path or not self.snakemake_config_path:
+            print("No snakefile or config path set, skipping status map load")
+            return
+        
+        try:
+            # Run summary for current config scope only
+            print("Running summary for current config scope...")
+            self.current_scope_files = self._run_snakemake_summary(
+                self.snakefile_path,
+                self.snakemake_config_path
+            )
+            print(f"  ✓ Loaded status for {len(self.current_scope_files)} files in current config")
+            
+            # No need for full scope summary - files not in current scope will be gray
+            self.all_scope_files = {}
+            
+            # Also update legacy file_status_map for backward compatibility
+            self.file_status_map = self.current_scope_files
+            
+            print(f"=== File status map loaded successfully ===\n")
+            
+        except Exception as e:
+            print(f"Error loading file status maps: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            # Fallback to empty maps
+            self.current_scope_files = {}
+            self.all_scope_files = {}
+            self.file_status_map = {}
+    
+    def _run_snakemake_summary(self, snakefile_path, config_path, target_rule='all_default'):
+        """Run snakemake with --summary to get status of all workflow files"""
+        try:
+            # Build command with conda activation if environment is set
+            if self.conda_env:
+                # Use 'conda run' for proper environment activation
+                cmd = ['conda', 'run', '-n', self.conda_env, '--no-capture-output', 
+                       'snakemake', '-s', snakefile_path, '--configfile', config_path, '--nolock', '--summary', target_rule]
+            else:
+                cmd = ['snakemake', '-s', snakefile_path, '--configfile', config_path, '--nolock', '--summary', target_rule]
+            
+            print(f"DEBUG: Running summary command: {' '.join(cmd)}")
+            
+            # Run the summary command
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            
+            print(f"DEBUG: Summary exit code: {result.returncode}")
+            print(f"DEBUG: Summary stdout length: {len(result.stdout)}")
+            print(f"DEBUG: Summary stderr length: {len(result.stderr)}")
+            
+            if result.returncode != 0:
+                print(f"ERROR: Summary command failed")
+                print(f"STDERR: {result.stderr[:500]}")
+                return {}
+            
+            # Parse summary table output
+            # Format: output_file\tdate\trule\tlog-file(s)\tstatus\tplan
+            # Columns are tab-separated
+            file_status_map = {}
+            lines = result.stdout.split('\n')
+            
+            for line in lines:
+                line = line.strip()
+                # Skip empty lines and header
+                if not line or line.startswith('output_file') or line.startswith('Building'):
+                    continue
+                
+                # Split by tabs (the table is tab-delimited)
+                parts = line.split('\t')
+                if len(parts) >= 6:
+                    # Extract columns: file, date, rule, log, status, plan
+                    file_path = parts[0].strip()
+                    date_str = parts[1].strip()
+                    rule = parts[2].strip()
+                    log_file = parts[3].strip()
+                    status = parts[4].strip()
+                    plan = parts[5].strip()  # Can be "no update", "update pending", etc.
+                    
+                    # Normalize path to handle Windows paths
+                    file_path = os.path.normpath(file_path)
+                    
+                    file_status_map[file_path] = {
+                        'date': date_str,
+                        'rule': rule,
+                        'status': status,
+                        'plan': plan
+                    }
+            
+            print(f"DEBUG: Summary parsed {len(file_status_map)} files")
+            if file_status_map:
+                print("DEBUG: Sample file statuses:")
+                for f, info in list(file_status_map.items())[:3]:
+                    print(f"  {os.path.basename(f)}: status={info['status']}, plan={info['plan']}")
+            
+            return file_status_map
+            
+        except subprocess.TimeoutExpired:
+            print("Dry run timed out after 30 seconds")
+            return set()
+        except Exception as e:
+            print(f"Error running dry run: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            return set()
+    
+    def _save_pipeline_status_on_start(self):
+        """Save pipeline status when starting a run"""
+        if not self.snakemake_config_path:
+            return
+            
+        try:
+            derivatives_dir = os.path.dirname(self.snakemake_config_path)
+            
+            # Get current timestamp
+            current_time = datetime.now().isoformat()
+            
+            # Build status dict
+            pipeline_status = {
+                'last_run_time': current_time,
+                'status': 'running',
+                'expected_outputs': list(self.expected_pipeline_outputs),
+                'completed_outputs': []
+            }
+            
+            print(f"DEBUG: Saving pipeline status - last_run_time={current_time}")
+            print(f"DEBUG: Expected outputs: {len(self.expected_pipeline_outputs)} files")
+            
+            # Save to homer.config
+            self._save_homer_config(
+                self.snakefile_path,
+                self.snakemake_config_path,
+                derivatives_dir,
+                pipeline_status
+            )
+            
+            self.pipeline_status = pipeline_status
+            self.completed_pipeline_outputs = set()  # Reset completed outputs
+            print(f"DEBUG: Pipeline status saved and set in memory")
+            
+        except Exception as e:
+            print(f"Warning: Could not save pipeline status: {str(e)}")
+    
+    def _restore_pipeline_state(self):
+        """Restore pipeline state from homer.config and update file colors"""
+        if not self.snakemake_config_path:
+            return
+            
+        try:
+            derivatives_dir = os.path.dirname(self.snakemake_config_path)
+            homer_config_path = os.path.join(derivatives_dir, 'homer.config')
+            
+            if os.path.exists(homer_config_path):
+                with open(homer_config_path, 'r') as f:
+                    homer_config = yaml.safe_load(f) or {}
+                
+                self.pipeline_status = homer_config.get('pipeline_status', {})
+                print(f"DEBUG: Restored pipeline_status: {self.pipeline_status}")
+                
+                # Restore expected and completed outputs
+                self.expected_pipeline_outputs = set(self.pipeline_status.get('expected_outputs', []))
+                self.completed_pipeline_outputs = set(self.pipeline_status.get('completed_outputs', []))
+                print(f"DEBUG: Restored {len(self.expected_pipeline_outputs)} expected outputs")
+                print(f"DEBUG: Restored {len(self.completed_pipeline_outputs)} completed outputs")
+                
+                # Get current file status from summary
+                if self.snakefile_path and self.snakemake_config_path:
+                    print("DEBUG: Running summary to get current file status...")
+                    self.file_status_map = self._run_snakemake_summary(
+                        self.snakefile_path,
+                        self.snakemake_config_path
+                    )
+                
+                # Update colors for all current files
+                self._update_all_file_colors()
+                
+                # Update the currently selected item colors in the comboboxes
+                self._update_combobox_selection_colors()
+                
+                # If pipeline was running, check if it's STILL running
+                if self.pipeline_status.get('status') == 'running':
+                    # Validate the stored process is still running
+                    if self._is_stored_pipeline_running():
+                        print("DEBUG: Stored pipeline process is still running, resuming monitoring")
+                        self._start_pipeline_monitoring()
+                    else:
+                        print("DEBUG: Stored pipeline process no longer running, updating status")
+                        # Pipeline finished while GUI was closed
+                        self.pipeline_status['status'] = 'completed'
+                        self.pipeline_status['completed_time'] = datetime.now().isoformat()
+                        derivatives_dir = os.path.dirname(self.snakemake_config_path)
+                        self._save_homer_config(
+                            self.snakefile_path,
+                            self.snakemake_config_path,
+                            derivatives_dir,
+                            self.pipeline_status
+                        )
+                        self.statbar.showMessage("Pipeline completed while GUI was closed")
+                    
+        except Exception as e:
+            print(f"Warning: Could not restore pipeline state: {str(e)}")
+    
+    def _is_stored_pipeline_running(self):
+        """Check if the stored pipeline process (PID + start time) is still running"""
+        stored_pid = self.pipeline_status.get('process_pid')
+        stored_start_time = self.pipeline_status.get('process_start_time')
+        
+        if not stored_pid:
+            print("DEBUG _is_stored_pipeline_running: No stored PID found")
+            return False
+        
+        print(f"DEBUG _is_stored_pipeline_running: Checking PID={stored_pid}")
+        
+        try:
+            import psutil
+            
+            # Check if process with stored PID exists
+            if psutil.pid_exists(stored_pid):
+                proc = psutil.Process(stored_pid)
+                proc_name = proc.name()
+                print(f"DEBUG _is_stored_pipeline_running: PID={stored_pid} exists, name={proc_name}")
+                
+                # Verify it's the same process by comparing start time
+                # (PIDs can be reused after process dies)
+                if stored_start_time:
+                    actual_start_time = proc.create_time()
+                    time_diff = abs(actual_start_time - stored_start_time)
+                    print(f"DEBUG _is_stored_pipeline_running: Start time diff={time_diff:.2f}s")
+                    if time_diff < 1.0:  # Within 1 second
+                        # Verify it's actually a snakemake process
+                        cmdline = ' '.join(proc.cmdline()).lower()
+                        has_snakemake = 'snakemake' in cmdline
+                        print(f"DEBUG _is_stored_pipeline_running: Has 'snakemake' in cmdline: {has_snakemake}")
+                        if has_snakemake:
+                            print(f"DEBUG _is_stored_pipeline_running: ✓ Pipeline process validated as running")
+                            return True
+                        else:
+                            print(f"DEBUG _is_stored_pipeline_running: PID={stored_pid} exists but is not snakemake (PID reused)")
+                    else:
+                        print(f"DEBUG _is_stored_pipeline_running: PID={stored_pid} exists but start time mismatch (PID reused)")
+                else:
+                    # No start time stored, just check if it's snakemake
+                    cmdline = ' '.join(proc.cmdline()).lower()
+                    if 'snakemake' in cmdline:
+                        print(f"DEBUG _is_stored_pipeline_running: ✓ Snakemake found (no start time check)")
+                        return True
+            else:
+                print(f"DEBUG _is_stored_pipeline_running: PID={stored_pid} does not exist")
+                
+            return False
+            
+        except psutil.NoSuchProcess:
+            print(f"DEBUG _is_stored_pipeline_running: Process PID={stored_pid} no longer exists (NoSuchProcess)")
+            return False
+        except Exception as e:
+            print(f"ERROR _is_stored_pipeline_running: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            return False
+    
+    def _start_pipeline_monitoring(self):
+        """Start the QTimer to monitor file updates every 30 seconds"""
+        if self.pipeline_monitor_timer is None:
+            self.pipeline_monitor_timer = QtCore.QTimer(self)
+            self.pipeline_monitor_timer.timeout.connect(self._check_file_updates)
+        
+        # Check immediately, then every 30 seconds
+        self._check_file_updates()
+        self.pipeline_monitor_timer.start(30000)  # 30 seconds
+        
+        self.statbar.showMessage("Pipeline monitoring active...")
+    
+    def _stop_pipeline_monitoring(self):
+        """Stop the monitoring timer and cancel any running worker"""
+        if self.pipeline_monitor_timer:
+            self.pipeline_monitor_timer.stop()
+        
+        # Cancel and clean up any running summary worker
+        if self.summary_worker and self.summary_worker.isRunning():
+            print("DEBUG: Canceling running summary worker...")
+            self.summary_worker.cancel()
+            self.summary_worker.wait(3000)  # Wait up to 3 seconds for thread to finish
+            if self.summary_worker.isRunning():
+                print("WARNING: Summary worker did not stop in time")
+            self.summary_worker = None
+        
+        self.statbar.showMessage("Pipeline monitoring stopped")
+    
+    def _check_file_updates(self):
+        """Start background summary check to monitor pipeline progress"""
+        print("DEBUG: _check_file_updates() called")
+        
+        if not self.snakemake_config_path:
+            print("DEBUG: No snakemake_config_path, returning")
+            return
+        
+        # Skip updates if pipeline is not running
+        if self.pipeline_status.get('status') != 'running':
+            print("DEBUG: Pipeline not running, stopping monitoring")
+            self._stop_pipeline_monitoring()
+            return
+        
+        # Don't start new worker if one is already running
+        if self.summary_worker and self.summary_worker.isRunning():
+            print("DEBUG: Summary worker still running, skipping this check")
+            return
+        
+        try:
+            # Determine which config to use for monitoring
+            # In "run current only" mode, monitor only the temp config (file being processed)
+            # Use the actual config that was used for execution (temp or original)
+            monitor_config = getattr(self, '_actual_config_used', self.snakemake_config_path)
+            if self.run_current_only_mode:
+                print(f"DEBUG: Monitoring temp config (selected file only): {monitor_config}")
+            else:
+                print(f"DEBUG: Monitoring with current config: {monitor_config}")
+            
+            # Reload config file to pick up any changes
+            with open(monitor_config, 'r') as f:
+                self.snakemake_config = yaml.safe_load(f)
+            
+            # Start background worker to get current file status from summary
+            if self.snakefile_path and monitor_config:
+                print("DEBUG: Starting background summary check...")
+                self.summary_worker = SummaryWorker(
+                    self.snakefile_path,
+                    monitor_config,
+                    self.conda_env
+                )
+                self.summary_worker.summary_completed.connect(self._on_summary_completed)
+                self.summary_worker.summary_failed.connect(self._on_summary_failed)
+                self.summary_worker.start()
+                self.statbar.showMessage("Updating pipeline status...")
+                
+        except Exception as e:
+            print(f"Error checking file updates: {str(e)}")
+    
+    def _on_summary_completed(self, file_status_map):
+        """Handle summary results from background worker (runs in main GUI thread)"""
+        try:
+            print(f"DEBUG: Summary completed with {len(file_status_map)} files")
+            
+            # Update the file status maps
+            # In "run current only" mode, UPDATE the existing scope (don't replace)
+            # This preserves the initial full-config summary while updating the selected file
+            if self.run_current_only_mode:
+                print(f"DEBUG: Updating file status (merge mode for current selection)")
+                # Update only the files in the new summary, keep others unchanged
+                for file_path, status_info in file_status_map.items():
+                    self.current_scope_files[file_path] = status_info
+                    print(f"DEBUG: Updated status for {file_path}")
+            else:
+                # Normal mode: replace entire scope
+                print(f"DEBUG: Replacing entire file status map (normal mode)")
+                self.current_scope_files = file_status_map
+            
+            self.file_status_map = self.current_scope_files  # Backward compatibility
+            self.all_scope_files = {}  # No dual summary
+            
+            # Update colors for all files based on current state
+            files_changed_to_black = self._update_all_file_colors()
+            
+            # Force comboboxes to repaint to show updated colors
+            if hasattr(self, 'subj'):
+                self.subj.repaint()
+                # Also repaint the dropdown view
+                if self.subj.view():
+                    self.subj.view().repaint()
+            if hasattr(self, 'run'):
+                self.run.repaint()
+                if self.run.view():
+                    self.run.view().repaint()
+            
+            # Update currently selected item colors
+            self._update_combobox_selection_colors()
+            
+            # Check for newly completed files and update homer.config
+            self._update_completed_outputs()
+            
+            # Clear cache for files that changed to black so they reload fresh
+            if files_changed_to_black:
+                print(f"DEBUG: {len(files_changed_to_black)} files changed to black, clearing cache")
+                self._mark_updated_files_for_reload(files_changed_to_black)
+            
+            # Only check pipeline completion and update monitoring status if still running
+            if self.pipeline_status.get('status') == 'running':
+                # Check if pipeline process has completed
+                self._check_pipeline_completion()
+                
+                # Update status bar with monitoring info (only if still running after check)
+                if self.pipeline_status.get('status') == 'running':
+                    completed_count = sum(1 for info in file_status_map.values() 
+                                         if info.get('status') == 'ok' and 'no update' in info.get('plan', '').lower())
+                    total_count = len(file_status_map)
+                    self.statbar.showMessage(f"Pipeline monitoring: {completed_count}/{total_count} files complete")
+            else:
+                print("DEBUG: Pipeline not running, skipping completion check")
+            
+        except Exception as e:
+            print(f"Error handling summary results: {str(e)}")
+    
+    def _on_summary_failed(self, error_msg):
+        """Handle summary failure from background worker"""
+        print(f"WARNING: Background summary check failed: {error_msg}")
+    
+    def _update_completed_outputs(self):
+        """Check expected outputs and mark completed ones, save to homer.config"""
+        if not self.expected_pipeline_outputs or not self.pipeline_status.get('last_run_time'):
+            return
+        
+        try:
+            last_run_time = datetime.fromisoformat(self.pipeline_status['last_run_time'])
+            newly_completed = []
+            
+            # Check each expected output
+            for file_path in self.expected_pipeline_outputs:
+                # Skip if already marked as completed
+                if file_path in self.completed_pipeline_outputs:
+                    continue
+                
+                # Check if file exists and is newer than pipeline start
+                if os.path.exists(file_path):
+                    file_mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
+                    if file_mtime >= (last_run_time - timedelta(seconds=5)):
+                        self.completed_pipeline_outputs.add(file_path)
+                        newly_completed.append(file_path)
+            
+            # If we found newly completed files, update homer.config
+            if newly_completed:
+                print(f"DEBUG: {len(newly_completed)} new files completed")
+                self.pipeline_status['completed_outputs'] = list(self.completed_pipeline_outputs)
+                
+                derivatives_dir = os.path.dirname(self.snakemake_config_path)
+                self._save_homer_config(
+                    self.snakefile_path,
+                    self.snakemake_config_path,
+                    derivatives_dir,
+                    self.pipeline_status
+                )
+                
+        except Exception as e:
+            print(f"Error updating completed outputs: {str(e)}")
+    
+    def _check_pipeline_completion(self):
+        """Check if the Snakemake pipeline is still running using stored process info"""
+        print("DEBUG _check_pipeline_completion: Called")
+        print(f"DEBUG _check_pipeline_completion: Status = {self.pipeline_status.get('status')}")
+        
+        if self.pipeline_status.get('status') != 'running':
+            print("DEBUG _check_pipeline_completion: Status is not 'running', returning")
+            return
+        
+        # If we don't have a PID, we can't check completion via process monitoring
+        # This can happen if PID detection failed at launch
+        if not self.pipeline_status.get('process_pid'):
+            print("DEBUG _check_pipeline_completion: No PID stored, cannot check completion via process monitoring")
+            return
+            
+        try:
+            # Use stored PID validation instead of scanning all processes
+            snakemake_running = self._is_stored_pipeline_running()
+            print(f"DEBUG _check_pipeline_completion: _is_stored_pipeline_running returned {snakemake_running}")
+            
+            # If stored process not running, pipeline has completed
+            if not snakemake_running:
+                print(f"DEBUG _check_pipeline_completion: Pipeline detected as completed!")
+                
+                # Do final summary check to get latest file states
+                print("DEBUG _check_pipeline_completion: Running final summary check...")
+                if self.snakefile_path and self.snakemake_config_path:
+                    # Use temp config for final summary in "run current only" mode
+                    # This checks the file we actually processed, not all files in original config
+                    if self.run_current_only_mode and hasattr(self, '_actual_config_used'):
+                        final_summary_config = self._actual_config_used  # temp config
+                        print(f"DEBUG: Using temp config for final summary (selected file only): {final_summary_config}")
+                    else:
+                        final_summary_config = self.snakemake_config_path
+                        print(f"DEBUG: Using current config for final summary: {final_summary_config}")
+                    
+                    file_status_map = self._run_snakemake_summary(
+                        self.snakefile_path,
+                        final_summary_config
+                    )
+                    
+                    # In "run current only" mode, MERGE results (don't replace entire scope)
+                    # This preserves the initial status of non-selected files
+                    if self.run_current_only_mode:
+                        print(f"DEBUG: Merging final summary (preserving non-selected files)")
+                        for file_path, status_info in file_status_map.items():
+                            self.current_scope_files[file_path] = status_info
+                        self.file_status_map = self.current_scope_files
+                    else:
+                        # Normal mode: replace entire scope
+                        self.current_scope_files = file_status_map
+                        self.file_status_map = file_status_map
+                        
+                    self.all_scope_files = {}  # No dual summary
+                    print(f"DEBUG _check_pipeline_completion: Final summary returned {len(file_status_map)} files")
+                
+                derivatives_dir = os.path.dirname(self.snakemake_config_path)
+                
+                # Update status - check latest snakemake log for success/failure
+                status = 'completed'
+                snakemake_log_dir = os.path.join(
+                    os.path.dirname(os.path.dirname(derivatives_dir)),
+                    '.snakemake', 'log'
+                )
+                
+                # Check if there were errors in the latest log
+                if os.path.exists(snakemake_log_dir):
+                    try:
+                        logs = sorted(os.listdir(snakemake_log_dir), reverse=True)
+                        if logs:
+                            latest_log = os.path.join(snakemake_log_dir, logs[0])
+                            with open(latest_log, 'r') as f:
+                                log_content = f.read()
+                                if 'error' in log_content.lower() or 'failed' in log_content.lower():
+                                    status = 'failed'
+                    except:
+                        pass
+                
+                # Update status in homer.config
+                self.pipeline_status['status'] = status
+                self.pipeline_status['completed_time'] = datetime.now().isoformat()
+                self._save_homer_config(
+                    self.snakefile_path,
+                    self.snakemake_config_path,
+                    derivatives_dir,
+                    self.pipeline_status
+                )
+                
+                # Stop monitoring
+                self._stop_pipeline_monitoring()
+                self.snakemake_process = None
+                
+                # Clear "run on current selection only" mode
+                self.run_current_only_mode = False
+                self.current_selection_subject = None
+                self.current_selection_task = None
+                self.current_selection_run = None
+                print("DEBUG: Cleared 'run current only' mode")
+                
+                # Update file colors with final summary (orange files should turn red/black)
+                self._update_all_file_colors()
+                
+                # Update status bar
+                self.statbar.showMessage(f"Pipeline {status}")
+                            
+        except Exception as e:
+            print(f"Error checking pipeline completion: {str(e)}")
+    
+    def _update_all_file_colors(self):
+        """Update colors for all subject/run combinations and return list of files that changed to black"""
+        if not self.snakemake_config:
+            return []
+        
+        files_changed_to_black = []  # List of (subject, run) tuples that changed to black
+        dataset = self.snakemake_config.get('dataset', {})
+        subjects = dataset.get('subject', [])
+        runs = dataset.get('run', [])
+        
+        print(f"DEBUG: Config subjects: {subjects}")
+        print(f"DEBUG: Config runs: {runs}")
+        print(f"DEBUG: GUI subjects: {self.subjects}")
+        print(f"DEBUG: GUI subject_to_runs_map: {self.subject_to_runs_map}")
+        
+        # First pass: collect all run colors per subject
+        subject_run_colors = {}  # {subject: [(run, color), ...]}
+        
+        for subject in self.subjects:
+            if subject == "None":
+                continue
+            available_runs = self.subject_to_runs_map.get(subject, [])
+            subject_run_colors[subject] = []
+            
+            for run in available_runs:
+                if run == "None":
+                    continue
+                    
+                old_color = self.file_colors.get((subject, run))
+                new_color = self._get_file_color(subject, run, subjects, runs)
+                
+                print(f"DEBUG: Subject={subject}, Run={run}, Old={old_color}, New={new_color}")
+                
+                if old_color != new_color:
+                    self.file_colors[(subject, run)] = new_color
+                    # Track files that changed to black (newly completed)
+                    if new_color == 'black':
+                        files_changed_to_black.append((subject, run))
+                        print(f"DEBUG: File changed to black: {subject} {run}")
+                
+                subject_run_colors[subject].append((run, new_color))
+        
+        # Second pass: apply colors and determine subject aggregate color
+        for subject, run_colors in subject_run_colors.items():
+            # Determine subject color priority: black > orange > red > gray
+            # Priority explanation:
+            # - black: at least one file in scope is complete (best)
+            # - orange: at least one file in scope needs work, pipeline running
+            # - red: at least one file in scope needs work, pipeline stopped
+            # - gray: all files out of scope (or no files found)
+            subject_color = 'gray'  # Default
+            for run, color in run_colors:
+                if color == 'black':
+                    subject_color = 'black'
+                    break  # Highest priority
+                elif color == 'orange' and subject_color not in ['black']:
+                    subject_color = 'orange'
+                elif color == 'red' and subject_color not in ['black', 'orange']:
+                    subject_color = 'red'
+            
+            # Apply run colors
+            for run, color in run_colors:
+                self._apply_run_color_to_combobox(subject, run, color)
+            
+            # Apply subject color once
+            self._apply_subject_color_to_combobox(subject, subject_color)
+        
+        return files_changed_to_black
+    
+    def _is_pipeline_running(self):
+        """Check if the Snakemake pipeline is currently running"""
+        # Check pipeline status from config
+        status = self.pipeline_status.get('status')
+        print(f"DEBUG _is_pipeline_running: pipeline_status.status = '{status}'")
+        
+        if status == 'running':
+            # Verify process is actually still alive
+            is_running = self._is_stored_pipeline_running()
+            print(f"DEBUG _is_pipeline_running: _is_stored_pipeline_running returned {is_running}")
+            return is_running
+        
+        print(f"DEBUG _is_pipeline_running: Status is not 'running', returning False")
+        return False
+    
+    def _get_file_color(self, subject, run, config_subjects, config_runs):
+        """
+        Determine color for a subject/run combination.
+        
+        The file checked depends on the current view mode:
+        - Normal view: checks preprocessing file status
+        - HRF view: checks HRF estimate file status
+        
+        Normal mode (4 colors):
+        - Black: In current scope, up-to-date
+        - Gray: Not in current scope (any status)
+        - Orange: In current scope, needs update, pipeline running
+        - Red: In current scope, needs update, pipeline stopped
+        
+        "Run on current selection only" mode (3-tier):
+        - Selected file: Orange (needs update) or Black (up-to-date)
+        - Non-selected file, up-to-date: Black (already done)
+        - Non-selected file, needs update: Red (needs work but skipping)
+        - Gray: File not in GUI config at all
+        """
+        # Choose which file to check based on view mode
+        if self.hrf_view.isChecked():
+            file_path = self._get_expected_file_path(subject, run)  # HRF estimate file
+            file_type = "HRF estimate"
+        else:
+            file_path = self._get_preprocessing_file_path(subject, run)  # Preprocessing file
+            file_type = "preprocessing"
+        
+        print(f"DEBUG _get_file_color: subject={subject}, run={run}")
+        print(f"DEBUG: Looking for {file_type} file: {file_path}")
+        
+        if not file_path:
+            print(f"DEBUG: Could not determine {file_type} path, returning gray")
+            return 'gray'
+        
+        # Check if file is in current scope (user's config)
+        in_current_scope = file_path in self.current_scope_files
+        print(f"DEBUG: In current scope? {in_current_scope}")
+        
+        if not in_current_scope:
+            # Not in current config → gray (don't care about status)
+            print(f"DEBUG: Not in current scope, returning gray")
+            return 'gray'
+        
+        # Get status from current scope map
+        status_info = self.current_scope_files[file_path]
+        status = status_info.get('status', '')
+        plan = status_info.get('plan', '')
+        print(f"DEBUG: status='{status}', plan='{plan}'")
+        
+        # Check if file is up to date
+        # File is up-to-date if it exists (ok) AND Snakemake says no update needed
+        is_up_to_date = (status == 'ok' and 'no update' in plan.lower())
+        print(f"DEBUG: is_up_to_date={is_up_to_date} (status==ok: {status == 'ok'}, 'no update' in plan: {'no update' in plan.lower()})")
+        
+        # Special handling for "Run on current selection only" mode
+        if self.run_current_only_mode:
+            print(f"DEBUG: In 'run current only' mode")
+            
+            # Parse subject/task/run from parameters
+            # subject format: "sub-15" → "15"
+            # run format: "task-IWHD_run-01" → task="IWHD", run_id="01"
+            subject_match = re.search(r'sub-(\w+)', subject) if subject else None
+            task_match = re.search(r'task-(.+?)(?:_run-|$)', run) if run else None
+            run_match = re.search(r'run-(\w+)', run) if run else None
+            
+            file_subject = subject_match.group(1) if subject_match else None
+            file_task = task_match.group(1) if task_match else None
+            file_run = run_match.group(1) if run_match else None
+            
+            # Check if this file matches the current selection
+            is_selected = (
+                file_subject == self.current_selection_subject and
+                file_task == self.current_selection_task and
+                file_run == self.current_selection_run
+            )
+            
+            print(f"DEBUG: File: sub-{file_subject}, task-{file_task}, run-{file_run}")
+            print(f"DEBUG: Selection: sub-{self.current_selection_subject}, task-{self.current_selection_task}, run-{self.current_selection_run}")
+            print(f"DEBUG: Matches selection? {is_selected}")
+            
+            if is_selected:
+                # Tier 1: File matches current selection (will be processed)
+                if is_up_to_date:
+                    print(f"DEBUG: Selected file, up to date → black")
+                    return 'black'
+                else:
+                    # Needs update and will be processed
+                    color = 'orange' if self._is_pipeline_running() else 'red'
+                    print(f"DEBUG: Selected file, needs update, pipeline_running={self._is_pipeline_running()} → {color}")
+                    return color
+            else:
+                # Tier 2: File in GUI config but not selected (won't be processed this run)
+                if is_up_to_date:
+                    print(f"DEBUG: Not selected, up to date → black")
+                    return 'black'
+                else:
+                    # Needs update but won't be processed in this run
+                    print(f"DEBUG: Not selected, needs update → red (won't be processed)")
+                    return 'red'
+        
+        # Normal mode (not in "run current only")
+        if is_up_to_date:
+            # In scope and up to date
+            print(f"DEBUG: Up to date, returning black")
+            return 'black'
+        else:
+            # In scope and needs update
+            # Orange if pipeline running, red if stopped
+            color = 'orange' if self._is_pipeline_running() else 'red'
+            print(f"DEBUG: Needs update, pipeline_running={self._is_pipeline_running()}, color={color}")
+            return color
+    
+    def _check_file_exists(self, subject, run):
+        """Check if the expected output file exists"""
+        try:
+            file_path = self._get_expected_file_path(subject, run)
+            if file_path and os.path.exists(file_path):
+                return True
+            return False
+        except Exception as e:
+            print(f"Error checking file existence: {str(e)}")
+            return False
+    
+    def _is_file_processed(self, subject, run):
+        """Check if a file has been processed based on mtime vs last_run_time"""
+        if not self.pipeline_status.get('last_run_time'):
+            # No pipeline run yet, file is not processed
+            print(f"DEBUG: No last_run_time in pipeline_status")
+            return False
+        
+        try:
+            # Get the expected file path
+            file_path = self._get_expected_file_path(subject, run)
+            if not file_path or not os.path.exists(file_path):
+                print(f"DEBUG: File not found: {file_path}")
+                return False
+            
+            # Get file modification time
+            file_mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
+            last_run_time = datetime.fromisoformat(self.pipeline_status['last_run_time'])
+            
+            print(f"DEBUG: {subject}/{run} - file_mtime={file_mtime}, last_run_time={last_run_time}")
+            
+            # File is processed if modified after (or close to) pipeline start
+            # Allow 5 second tolerance for clock sync issues
+            return file_mtime >= (last_run_time - timedelta(seconds=5))
+            
+        except Exception as e:
+            print(f"Error checking file processing status: {str(e)}")
+            return False
+    
+    def _get_preprocessing_file_path(self, subject, run):
+        """Get the preprocessing file path (unique per run) for checking if run is in workflow"""
+        if not self.snakemake_config_path:
+            return None
+        
+        try:
+            config_dir = os.path.dirname(self.snakemake_config_path)
+            
+            # Extract task and run number from combined run string
+            # e.g., "task-STS_run-01" -> task="STS", run_num="01"
+            task = run.split('task-')[1].split('_')[0] if 'task-' in run else 'unknown'
+            run_num = run.split('run-')[1] if 'run-' in run else '01'
+            
+            # Construct preprocessing file path matching Snakemake output format:
+            # derivatives/cedalion/XXX/preprocessed_data/sub-10/sub-10_task-STS_run-01_nirs_preprocessed.snirf
+            preproc_path = os.path.join(
+                config_dir,
+                'preprocessed_data',
+                subject,
+                f"{subject}_task-{task}_run-{run_num}_nirs_preprocessed.snirf"
+            )
+            return os.path.normpath(preproc_path)
+        except Exception as e:
+            return None
+    
+    def _has_preprocessing(self, subject, run):
+        """Check if preprocessing file exists for this subject/run"""
+        preproc_path = self._get_preprocessing_file_path(subject, run)
+        return preproc_path and os.path.exists(preproc_path)
+    
+    def _get_expected_file_path(self, subject, run):
+        """Get the expected HRF estimate file path for pipeline output based on Snakemake structure"""
+        if not self.snakemake_config_path:
+            print(f"DEBUG: No snakemake_config_path")
+            return None
+        
+        try:
+            # Get the config directory and dataset info
+            config_dir = os.path.dirname(self.snakemake_config_path)
+            dataset = self.snakemake_config.get('dataset', {})
+            
+            # Extract task name from run (e.g., "task-STS_run-01" -> "STS")
+            task = run.split('task-')[1].split('_')[0] if 'task-' in run else 'unknown'
+            
+            # Get rec_str from hrf_estimation config (e.g., "conc", "od")
+            hrf_config = self.snakemake_config.get('hrf_estimation', {})
+            rec_str = hrf_config.get('rec_str', 'conc')
+            
+            # Construct expected output path matching Snakemake output format:
+            # derivatives/cedalion/XXX/hrf_estimate/sub-10/sub-10_task-STS_nirs_hrf_estimate_<rec_str>.nc
+            file_path = os.path.join(
+                config_dir,
+                'hrf_estimate',
+                subject,
+                f"{subject}_{run.split('_run-')[0]}_nirs_hrf_estimate_{rec_str}.nc"
+            )
+            
+            # Normalize to match summary output format
+            file_path = os.path.normpath(file_path)
+            
+            return file_path
+            
+        except Exception as e:
+            print(f"DEBUG: Error constructing file path: {str(e)}")
+            return None
+    
+    def _mark_updated_files_for_reload(self, files_changed_to_black):
+        """Clear cache for files that changed to black so they reload fresh on next selection"""
+        cleared_count = 0
+        for subject, run in files_changed_to_black:
+            cache_key = (subject, run)
+            if cache_key in self.cache:
+                del self.cache[cache_key]
+                cleared_count += 1
+                print(f"Cleared cache for {subject} {run} - will reload fresh processed data on next selection")
+        
+        if cleared_count > 0:
+            self.statbar.showMessage(f"Cleared cache for {cleared_count} newly completed file(s) - fresh data will load on selection")
+    
+    def _reapply_run_colors(self, subject, runs):
+        """Reapply colors to run items after run combobox is repopulated"""
+        if not self.snakemake_config:
+            return
+        
+        dataset = self.snakemake_config.get('dataset', {})
+        config_subjects = dataset.get('subject', [])
+        config_runs = dataset.get('run', [])
+        
+        for run in runs:
+            if run == "None":
+                continue
+            color = self._get_file_color(subject, run, config_subjects, config_runs)
+            self.file_colors[(subject, run)] = color
+            self._apply_run_color_to_combobox(subject, run, color)
+        
+        # Update the stylesheet for the currently selected run
+        self._update_combobox_selection_colors()
+    
+    def _update_combobox_selection_colors(self):
+        """Update the color of the currently selected text in comboboxes"""
+        color_map = {
+            'red': '#FF0000',
+            'orange': '#FF8C00',
+            'gray': '#808080',
+            'black': '#000000'
+        }
+        
+        # Update subject combobox current selection color
+        if hasattr(self, 'subj'):
+            current_subj = self.subj.currentText()
+            if current_subj != "None":
+                # Aggregate colors for this subject using priority: black > orange > red > gray
+                subject_color = 'gray'
+                for (subj, run), color in self.file_colors.items():
+                    if subj == current_subj:
+                        if color == 'black':
+                            subject_color = 'black'
+                            break
+                        elif color == 'orange' and subject_color not in ['black']:
+                            subject_color = 'orange'
+                        elif color == 'red' and subject_color not in ['black', 'orange']:
+                            subject_color = 'red'
+                
+                if subject_color:
+                    self.subj.setStyleSheet(f"QComboBox {{ color: {color_map[subject_color]}; }}")
+        
+        # Update run combobox current selection color
+        if hasattr(self, 'run'):
+            current_run = self.run.currentText()
+            current_subj = self.subj.currentText()
+            if current_run != "None" and current_subj != "None":
+                run_color = self.file_colors.get((current_subj, current_run))
+                if run_color:
+                    self.run.setStyleSheet(f"QComboBox {{ color: {color_map[run_color]}; }}")
+    
+    def _apply_color_to_combobox(self, subject, run, color):
+        """Apply color styling to combobox items for subject/run"""
+        self._apply_run_color_to_combobox(subject, run, color)
+        self._apply_subject_color_to_combobox(subject, color)
+    
+    def _apply_subject_color_to_combobox(self, subject, color):
+        """Apply color to subject in subject dropdown"""
+        color_map = {
+            'red': '#FF0000',
+            'orange': '#FF8C00',
+            'gray': '#808080',
+            'black': '#000000'
+        }
+        
+        try:
+            if hasattr(self, 'subj'):
+                idx = self.subj.findText(subject)
+                if idx >= 0:
+                    self.subj.setItemData(idx, QtGui.QColor(color_map[color]), QtCore.Qt.ForegroundRole)
+        except Exception as e:
+            print(f"Error applying color to subject combobox: {str(e)}")
+    
+    def _apply_run_color_to_combobox(self, subject, run, color):
+        """Apply color to run in run dropdown"""
+        # Map colors to Qt stylesheet colors
+        color_map = {
+            'red': '#FF0000',
+            'orange': '#FF8C00',
+            'gray': '#808080',
+            'black': '#000000'
+        }
+        
+        try:
+            # Update run combobox only if the current subject matches
+            if hasattr(self, 'run') and hasattr(self, 'subj'):
+                current_subject = self.subj.currentText()
+                if current_subject == subject:
+                    idx = self.run.findText(run)
+                    if idx >= 0:
+                        self.run.setItemData(idx, QtGui.QColor(color_map[color]), QtCore.Qt.ForegroundRole)
+        except Exception as e:
+            print(f"Error applying color to run combobox: {str(e)}")
+
+
+def run_vis(gui_data: dict):
+    """Opens the visualization GUI.
+
+    Args:
+        gui_data: A dictionary containing the data for visualization.
+    """
+
+    app = QtWidgets.QApplication(sys.argv)
+    main_gui = _MAIN_GUI(gui_data=gui_data)
+    main_gui.show()
+    sys.exit(app.exec())

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -1576,6 +1576,8 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                         print(f"Loading HRF data from: {hrf_file_path}")
                         hrf_data = xr.open_dataset(hrf_file_path)
                         print(f"HRF data loaded successfully")
+                        if hasattr(hrf_data, 'data_vars'):
+                            print(f"HRF data variables: {list(hrf_data.data_vars.keys())}")
                     else:
                         print(f"No HRF file found at: {hrf_file_path}")
             except Exception as e:
@@ -3937,31 +3939,40 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                         blockaverage = value
                         print(f"Found xarray data in key: {key}")
                         break
+        
+        # Extract standard error from total_stderr (group average) or mse_t (individual HRF)
+        # This runs for all hrf_data types (Dataset, DataArray, or dict)
+        print(f"DEBUG: Checking for stderr variables in hrf_data")
+        print(f"DEBUG: hrf_data type: {type(hrf_data)}")
+        if hasattr(hrf_data, 'data_vars'):
+            print(f"DEBUG: Available data_vars: {list(hrf_data.data_vars.keys())}")
+        if 'total_stderr' in hrf_data:
+            # Group average data has total_stderr already computed
+            stderr = hrf_data['total_stderr']
+            print(f"Found total_stderr with dims: {stderr.dims}")
+        elif 'mse_t' in hrf_data:
+            # Individual HRF data has mse_t which we convert to stderr
+            import numpy as np
+            mse_t = hrf_data['mse_t']
+            print(f"Found mse_t with dims: {mse_t.dims}")
             
-            # Extract standard error from total_stderr (group average) or mse_t (individual HRF)
-            if 'total_stderr' in hrf_data:
-                # Group average data has total_stderr already computed
-                stderr = hrf_data['total_stderr']
-                print(f"Found total_stderr with dims: {stderr.dims}")
-            elif 'mse_t' in hrf_data:
-                # Individual HRF data has mse_t which we convert to stderr
-                import numpy as np
-                mse_t = hrf_data['mse_t']
-                print(f"Found mse_t with dims: {mse_t.dims}")
-                
-                # Compute standard error: stderr = sqrt(mse_t)
-                stderr = np.sqrt(mse_t)
-                
-                # Transpose to match blockaverage dimensions if needed
-                # blockaverage dims: ('trial_type', 'channel', 'chromo', 'time')
-                # mse_t dims: ('trial_type', 'time', 'channel', 'chromo')
-                if blockaverage is not None and hasattr(blockaverage, 'dims'):
-                    target_dims = blockaverage.dims
-                    if stderr.dims != target_dims:
-                        stderr = stderr.transpose(*target_dims)
-                        print(f"Transposed stderr to dims: {stderr.dims}")
-                
-                print(f"Standard error computed and ready to pass to plot_probe")
+            # Compute standard error: stderr = sqrt(mse_t)
+            stderr = np.sqrt(mse_t)
+            
+            # Transpose to match blockaverage dimensions if needed
+            # blockaverage dims: ('trial_type', 'channel', 'chromo', 'time')
+            # mse_t dims: ('trial_type', 'time', 'channel', 'chromo')
+            if blockaverage is not None and hasattr(blockaverage, 'dims'):
+                target_dims = blockaverage.dims
+                if stderr.dims != target_dims:
+                    stderr = stderr.transpose(*target_dims)
+                    print(f"Transposed stderr to dims: {stderr.dims}")
+            
+            print(f"Standard error computed and ready to pass to plot_probe")
+        else:
+            print(f"DEBUG: No stderr data found - neither 'total_stderr' nor 'mse_t' in hrf_data")
+            if hasattr(hrf_data, 'data_vars'):
+                print(f"DEBUG: Available variables were: {list(hrf_data.data_vars.keys())}")
         
         if blockaverage is None or not hasattr(blockaverage, 'dims'):
             self.statbar.showMessage("Invalid HRF data format")
@@ -3985,6 +3996,8 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             print(f"Launching with HRF data dims: {blockaverage.dims}")
             if stderr is not None:
                 print(f"Passing stderr with dims: {stderr.dims}")
+            else:
+                print(f"WARNING: No stderr data to pass to plot_probe_gui")
             
             # Create the Plot Probe GUI as a child window (don't create new QApplication)
             self.plot_probe_window = _MAIN_GUI(

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -1717,6 +1717,16 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self.hrf_hbr.setEnabled(False)  # Will be enabled when HRF view is active
         hrf_checkbox_layout.addWidget(self.hrf_hbr)
         
+        # Add file type filter for color coding
+        hrf_checkbox_layout.addWidget(QtWidgets.QLabel("  |  Color by:"))
+        self.color_file_type = QtWidgets.QComboBox()
+        self.color_file_type.addItems(["Preprocessing", "HRF Estimate", "Image Recon", "All (any complete)"])
+        self.color_file_type.setCurrentText("Preprocessing")
+        self.color_file_type.setToolTip("Choose which file type to check for color coding status")
+        self.color_file_type.currentTextChanged.connect(self._color_file_type_changed)
+        self.color_file_type.setMinimumWidth(150)
+        hrf_checkbox_layout.addWidget(self.color_file_type)
+        
         # Add separator
         separator = QtWidgets.QFrame()
         separator.setFrameShape(QtWidgets.QFrame.VLine)
@@ -2395,6 +2405,22 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                     
                     # Save pipeline status and update colors only for actual runs (not dry runs or summaries)
                     if not dry_run and not show_summary:
+                        # Store target_rule for monitoring and final summary
+                        self.current_target_rule = target_rule
+                        
+                        # Check if there are actually files to process
+                        if self.expected_pipeline_outputs:
+                            print(f"DEBUG: {len(self.expected_pipeline_outputs)} files need processing - will clear cache")
+                            # Clear ALL cache ONLY if files need processing
+                            # This ensures fresh data loads when files complete, but preserves cache if nothing to do
+                            if self.cache:
+                                print(f"DEBUG: Clearing all cache ({len(self.cache)} entries) - files will be processed")
+                                self.cache.clear()
+                                self.statbar.showMessage(f"Starting pipeline - {len(self.expected_pipeline_outputs)} files to process")
+                        else:
+                            print(f"DEBUG: No files need processing - keeping cache intact")
+                            self.statbar.showMessage("All files already up-to-date - nothing to process")
+                        
                         # Save pipeline status before starting
                         self._save_pipeline_status_on_start()
                         
@@ -3344,6 +3370,23 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         """Handle changes to HRF chromophore selection"""
         if self.hrf_view.isChecked():
             self._draw_timeseries()
+    
+    def _color_file_type_changed(self):
+        """Handle changes to color file type filter - update all file colors"""
+        print(f"DEBUG: Color file type changed to: {self.color_file_type.currentText()}")
+        if self.snakemake_config:
+            self._update_all_file_colors()
+            # Force comboboxes to repaint
+            if hasattr(self, 'subj'):
+                self.subj.repaint()
+                if self.subj.view():
+                    self.subj.view().repaint()
+            if hasattr(self, 'run'):
+                self.run.repaint()
+                if self.run.view():
+                    self.run.view().repaint()
+            self._update_combobox_selection_colors()
+            self.statbar.showMessage(f"Color coding now based on: {self.color_file_type.currentText()}")
     
     def _launch_plot_probe(self):
         """Launch the Plot Probe GUI with current HRF data"""
@@ -5231,6 +5274,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             pipeline_status = {
                 'last_run_time': current_time,
                 'status': 'running',
+                'target_rule': getattr(self, 'current_target_rule', 'all_default'),
                 'expected_outputs': list(self.expected_pipeline_outputs),
                 'completed_outputs': []
             }
@@ -5277,10 +5321,13 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 
                 # Get current file status from summary
                 if self.snakefile_path and self.snakemake_config_path:
-                    print("DEBUG: Running summary to get current file status...")
+                    # Use the same target rule that was used to start the pipeline
+                    target_rule = self.pipeline_status.get('target_rule', 'all_default')
+                    print(f"DEBUG: Running summary with target_rule={target_rule} to get current file status...")
                     self.file_status_map = self._run_snakemake_summary(
                         self.snakefile_path,
-                        self.snakemake_config_path
+                        self.snakemake_config_path,
+                        target_rule
                     )
                 
                 # Update colors for all current files
@@ -5433,11 +5480,14 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             
             # Start background worker to get current file status from summary
             if self.snakefile_path and monitor_config:
-                print("DEBUG: Starting background summary check...")
+                # Use the same target rule that was used to start the pipeline
+                target_rule = self.pipeline_status.get('target_rule', 'all_default')
+                print(f"DEBUG: Starting background summary check with target_rule={target_rule}...")
                 self.summary_worker = SummaryWorker(
                     self.snakefile_path,
                     monitor_config,
-                    self.conda_env
+                    self.conda_env,
+                    target_rule
                 )
                 self.summary_worker.summary_completed.connect(self._on_summary_completed)
                 self.summary_worker.summary_failed.connect(self._on_summary_failed)
@@ -5491,8 +5541,38 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             
             # Clear cache for files that changed to black so they reload fresh
             if files_changed_to_black:
-                print(f"DEBUG: {len(files_changed_to_black)} files changed to black, clearing cache")
+                print(f"DEBUG: {len(files_changed_to_black)} files changed to black:")
+                for subj, run in files_changed_to_black:
+                    print(f"  - {subj} / {run}")
                 self._mark_updated_files_for_reload(files_changed_to_black)
+                
+                # Auto-reload if currently displayed file just completed
+                # NOTE: This only triggers ONCE when file status changes to black, not every 30 seconds
+                # files_changed_to_black only contains files that changed THIS update cycle
+                current_subj = self.subj.currentText() if hasattr(self, 'subj') else None
+                current_run = self.run.currentText() if hasattr(self, 'run') else None
+                
+                print(f"DEBUG: Currently displayed: subj='{current_subj}', run='{current_run}'")
+                print(f"DEBUG: Checking if ({current_subj}, {current_run}) in files_changed_to_black...")
+                
+                if current_subj and current_subj != "None" and current_run and current_run != "None":
+                    if (current_subj, current_run) in files_changed_to_black:
+                        print(f"DEBUG: MATCH! Currently displayed file {current_subj}/{current_run} completed - auto-reloading ONCE")
+                        self.statbar.showMessage(f"Auto-reloading {current_subj} {current_run} with fresh processed data...")
+                        # Trigger reload by calling the plot function
+                        QtCore.QTimer.singleShot(500, lambda: self._auto_reload_current_file())
+                    else:
+                        print(f"DEBUG: No match - displayed file not in changed list")
+                        # Check if ANY file type for this subject/run changed to black
+                        # (files_changed_to_black only tracks the "Color by" file type)
+                        # So let's check all file types manually
+                        any_file_changed = self._check_any_file_type_changed_to_black(current_subj, current_run)
+                        if any_file_changed:
+                            print(f"DEBUG: Another file type for {current_subj}/{current_run} completed - auto-reloading")
+                            self.statbar.showMessage(f"Auto-reloading {current_subj} {current_run} with fresh processed data...")
+                            QtCore.QTimer.singleShot(500, lambda: self._auto_reload_current_file())
+                else:
+                    print(f"DEBUG: Displayed file is None or empty - not auto-reloading")
             
             # Only check pipeline completion and update monitoring status if still running
             if self.pipeline_status.get('status') == 'running':
@@ -5589,9 +5669,14 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                         final_summary_config = self.snakemake_config_path
                         print(f"DEBUG: Using current config for final summary: {final_summary_config}")
                     
+                    # Use the same target rule that was used to start the pipeline
+                    target_rule = self.pipeline_status.get('target_rule', 'all_default')
+                    print(f"DEBUG: Using target_rule={target_rule} for final summary")
+                    
                     file_status_map = self._run_snakemake_summary(
                         self.snakefile_path,
-                        final_summary_config
+                        final_summary_config,
+                        target_rule
                     )
                     
                     # In "run current only" mode, MERGE results (don't replace entire scope)
@@ -5749,9 +5834,11 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         """
         Determine color for a subject/run combination.
         
-        The file checked depends on the current view mode:
-        - Normal view: checks preprocessing file status
-        - HRF view: checks HRF estimate file status
+        The file checked depends on the "Color by" selector:
+        - Preprocessing: checks preprocessing file status
+        - HRF Estimate: checks HRF estimate file status
+        - Image Recon: checks image reconstruction file status
+        - All (any complete): checks all three, shows black if any is complete
         
         Normal mode (4 colors):
         - Black: In current scope, up-to-date
@@ -5765,20 +5852,79 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         - Non-selected file, needs update: Red (needs work but skipping)
         - Gray: File not in GUI config at all
         """
-        # Choose which file to check based on view mode
-        if self.hrf_view.isChecked():
-            file_path = self._get_expected_file_path(subject, run)  # HRF estimate file
+        # Determine which file(s) to check based on color_file_type selector
+        color_by = self.color_file_type.currentText() if hasattr(self, 'color_file_type') else "Preprocessing"
+        
+        file_paths_to_check = []
+        
+        if color_by == "HRF Estimate":
+            file_path = self._get_expected_file_path(subject, run)
             file_type = "HRF estimate"
-        else:
-            file_path = self._get_preprocessing_file_path(subject, run)  # Preprocessing file
+            if file_path:
+                file_paths_to_check.append(file_path)
+        elif color_by == "Image Recon":
+            file_path = self._get_image_recon_file_path(subject, run)
+            file_type = "image reconstruction"
+            if file_path:
+                file_paths_to_check.append(file_path)
+        elif color_by == "All (any complete)":
+            # Check all three file types
+            file_type = "any (preprocess/HRF/image)"
+            for path in [
+                self._get_preprocessing_file_path(subject, run),
+                self._get_expected_file_path(subject, run),
+                self._get_image_recon_file_path(subject, run)
+            ]:
+                if path:
+                    file_paths_to_check.append(path)
+        else:  # Default: "Preprocessing"
+            file_path = self._get_preprocessing_file_path(subject, run)
             file_type = "preprocessing"
+            if file_path:
+                file_paths_to_check.append(file_path)
         
-        print(f"DEBUG _get_file_color: subject={subject}, run={run}")
-        print(f"DEBUG: Looking for {file_type} file: {file_path}")
+        print(f"DEBUG _get_file_color: subject={subject}, run={run}, color_by={color_by}")
+        print(f"DEBUG: Looking for {file_type} file(s): {file_paths_to_check}")
         
-        if not file_path:
-            print(f"DEBUG: Could not determine {file_type} path, returning gray")
+        if not file_paths_to_check:
+            print(f"DEBUG: Could not determine {file_type} path(s), returning gray")
             return 'gray'
+        
+        # For "All" mode, check if ANY file is in scope and up-to-date
+        if color_by == "All (any complete)":
+            any_in_scope = False
+            any_up_to_date = False
+            any_needs_update = False
+            
+            for file_path in file_paths_to_check:
+                if file_path in self.current_scope_files:
+                    any_in_scope = True
+                    status_info = self.current_scope_files[file_path]
+                    status = status_info.get('status', '')
+                    plan = status_info.get('plan', '')
+                    is_up_to_date = (status == 'ok' and 'no update' in plan.lower())
+                    
+                    if is_up_to_date:
+                        any_up_to_date = True
+                    else:
+                        any_needs_update = True
+            
+            if not any_in_scope:
+                print(f"DEBUG: No files in current scope, returning gray")
+                return 'gray'
+            
+            if any_up_to_date:
+                print(f"DEBUG: At least one file up to date, returning black")
+                return 'black'
+            elif any_needs_update:
+                color = 'orange' if self._is_pipeline_running() else 'red'
+                print(f"DEBUG: All files need update, returning {color}")
+                return color
+            else:
+                return 'gray'
+        
+        # Single file mode - check the specific file
+        file_path = file_paths_to_check[0]
         
         # Check if file is in current scope (user's config)
         in_current_scope = file_path in self.current_scope_files
@@ -5963,6 +6109,36 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             print(f"DEBUG: Error constructing file path: {str(e)}")
             return None
     
+    def _get_image_recon_file_path(self, subject, run):
+        """Get the expected image reconstruction file path for pipeline output"""
+        if not self.snakemake_config_path:
+            return None
+        
+        try:
+            config_dir = os.path.dirname(self.snakemake_config_path)
+            
+            # Extract task name from run (e.g., "task-STS_run-01" -> "STS")
+            task = run.split('task-')[1].split('_')[0] if 'task-' in run else 'unknown'
+            run_num = run.split('run-')[1] if 'run-' in run else '01'
+            
+            # Image reconstruction file path (individual subject):
+            # derivatives/cedalion/XXX/image_results/sub-10/Xs_sub-10_task-STS_run-01.nc
+            file_path = os.path.join(
+                config_dir,
+                'image_results',
+                subject,
+                f"Xs_{subject}_task-{task}_run-{run_num}.nc"
+            )
+            
+            # Normalize to match summary output format
+            file_path = os.path.normpath(file_path)
+            
+            return file_path
+            
+        except Exception as e:
+            print(f"DEBUG: Error constructing image recon path: {str(e)}")
+            return None
+    
     def _mark_updated_files_for_reload(self, files_changed_to_black):
         """Clear cache for files that changed to black so they reload fresh on next selection"""
         cleared_count = 0
@@ -5972,9 +6148,133 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 del self.cache[cache_key]
                 cleared_count += 1
                 print(f"Cleared cache for {subject} {run} - will reload fresh processed data on next selection")
+            
+            # Also update file_map to point to newly processed files
+            self._update_file_map_for_processed_data(subject, run)
         
         if cleared_count > 0:
             self.statbar.showMessage(f"Cleared cache for {cleared_count} newly completed file(s) - fresh data will load on selection")
+    
+    def _auto_reload_current_file(self):
+        """Auto-reload the currently displayed file after it completes processing"""
+        try:
+            print("DEBUG _auto_reload_current_file: Function called!")
+            current_subj = self.subj.currentText()
+            current_run = self.run.currentText()
+            
+            print(f"DEBUG _auto_reload_current_file: current_subj='{current_subj}', current_run='{current_run}'")
+            
+            if current_subj and current_subj != "None" and current_run and current_run != "None":
+                # First, update the file_map to point to the newly processed files
+                print(f"DEBUG _auto_reload_current_file: Updating file_map for {current_subj}/{current_run}")
+                self._update_file_map_for_processed_data(current_subj, current_run)
+                
+                print(f"DEBUG _auto_reload_current_file: Conditions met, calling _run_changed('{current_run}') for {current_subj}/{current_run}")
+                # Force a replot by calling the selection changed handler with the current run text
+                self._run_changed(current_run, subject_changed=False)
+                print(f"DEBUG _auto_reload_current_file: _run_changed() completed")
+                self.statbar.showMessage(f"Reloaded {current_subj} {current_run} with fresh data")
+            else:
+                print(f"DEBUG _auto_reload_current_file: Conditions not met (subject or run is None)")
+        except Exception as e:
+            print(f"ERROR auto-reloading file: {str(e)}")
+            import traceback
+            traceback.print_exc()
+    
+    def _update_file_map_for_processed_data(self, subject, run):
+        """Update file_map to point to newly processed files after pipeline completion"""
+        try:
+            print(f"DEBUG _update_file_map_for_processed_data: Updating paths for {subject}/{run}")
+            
+            # Construct the path to the newly processed file
+            if not self.snakemake_config_path:
+                print(f"DEBUG: No snakemake_config_path available")
+                return
+            
+            config_dir = os.path.dirname(self.snakemake_config_path)
+            
+            # Extract task and run number from combined run string
+            task = run.split('task-')[1].split('_')[0] if 'task-' in run else 'unknown'
+            run_num = run.split('run-')[1] if 'run-' in run else '01'
+            
+            # Construct preprocessed file path
+            preproc_path = os.path.join(
+                config_dir,
+                'preprocessed_data',
+                subject,
+                f"{subject}_task-{task}_run-{run_num}_nirs_preprocessed.snirf"
+            )
+            preproc_path = os.path.normpath(preproc_path)
+            
+            # Check if the file exists
+            if os.path.exists(preproc_path):
+                print(f"DEBUG: Found processed file: {preproc_path}")
+                
+                # Update file_map
+                if subject not in self.file_map:
+                    self.file_map[subject] = {}
+                if run not in self.file_map[subject]:
+                    self.file_map[subject][run] = {}
+                
+                # Update the pkl_path to point to the processed file
+                old_path = self.file_map[subject][run].get('pkl_path')
+                self.file_map[subject][run]['pkl_path'] = preproc_path
+                print(f"DEBUG: Updated pkl_path from '{old_path}' to '{preproc_path}'")
+            else:
+                print(f"DEBUG: Processed file not found at: {preproc_path}")
+                
+        except Exception as e:
+            print(f"ERROR updating file_map: {str(e)}")
+            import traceback
+            traceback.print_exc()
+    
+    def _check_any_file_type_changed_to_black(self, subject, run):
+        """Check if any file type (preprocessing, HRF, or image recon) just completed for this subject/run
+        
+        This checks all file types to see if any are now up-to-date in the current scope,
+        which would indicate they were just processed and should trigger an auto-reload.
+        """
+        try:
+            print(f"DEBUG _check_any_file_type_changed_to_black: checking {subject}/{run}")
+            
+            # Define the three file types to check
+            file_types = [
+                ("preprocessing", self._get_preprocessing_file_path(subject, run)),
+                ("HRF", self._get_expected_file_path(subject, run)),
+                ("image_recon", self._get_image_recon_file_path(subject, run))
+            ]
+            
+            for file_type_name, file_path in file_types:
+                if not file_path:
+                    print(f"DEBUG:   {file_type_name}: path not found")
+                    continue
+                    
+                if file_path not in self.current_scope_files:
+                    print(f"DEBUG:   {file_type_name}: not in current scope")
+                    continue
+                
+                status_info = self.current_scope_files[file_path]
+                status = status_info.get('status', '')
+                plan = status_info.get('plan', '')
+                is_up_to_date = (status == 'ok' and 'no update' in plan.lower())
+                
+                print(f"DEBUG:   {file_type_name}: status={status}, plan={plan}, up_to_date={is_up_to_date}")
+                
+                if is_up_to_date:
+                    # File is up-to-date in the current scope
+                    # This likely means it was just processed (since cache was cleared)
+                    # Or if running "current selection only", this is the file being processed
+                    print(f"DEBUG:   -> {file_type_name} file is up-to-date, triggering reload")
+                    return True
+            
+            print(f"DEBUG: No up-to-date files found in current scope for {subject}/{run}")
+            return False
+            
+        except Exception as e:
+            print(f"ERROR _check_any_file_type_changed_to_black: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            return False
     
     def _reapply_run_colors(self, subject, runs):
         """Reapply colors to run items after run combobox is repopulated"""

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -38,13 +38,15 @@ warnings.simplefilter("ignore")
 class ConfigEditorDialog(QtWidgets.QDialog):
     """Dialog for editing YAML configuration blocks"""
     
-    def __init__(self, config_data, block_name, readonly_keys=None, field_tooltips=None, parent=None):
+    def __init__(self, config_data, block_name, readonly_keys=None, field_tooltips=None, parent=None, file_map=None, subjects=None):
         super().__init__(parent)
         self.config_data = config_data
         self.block_name = block_name
         self.readonly_keys = readonly_keys or []
         self.field_tooltips = field_tooltips or {}  # Map of field_key -> tooltip text
         self.field_widgets = {}
+        self.file_map = file_map  # For dataset matching calculations
+        self.subjects = subjects  # Full subject list from GUI
         
         self.setWindowTitle(f"Edit {block_name.replace('_', ' ').title()} Configuration")
         self.setMinimumWidth(600)
@@ -54,6 +56,9 @@ class ConfigEditorDialog(QtWidgets.QDialog):
     
     def init_ui(self):
         layout = QtWidgets.QVBoxLayout()
+        
+        # Initialize matching_info_label early (before building form)
+        self.matching_info_label = None
         
         # Add scroll area for the form
         scroll = QtWidgets.QScrollArea()
@@ -67,6 +72,15 @@ class ConfigEditorDialog(QtWidgets.QDialog):
         self._build_form(self.config_data, "")
         
         layout.addWidget(scroll)
+        
+        # Add matching info label for dataset configuration (below form)
+        if self.block_name == 'dataset' and self.file_map and self.subjects:
+            self.matching_info_label = QtWidgets.QLabel()
+            self.matching_info_label.setStyleSheet("font-size: 11pt;")
+            self.matching_info_label.setWordWrap(True)
+            layout.addWidget(self.matching_info_label)
+            # Calculate initial matching info
+            self._update_matching_info()
         
         # Add buttons
         button_box = QtWidgets.QDialogButtonBox(
@@ -94,8 +108,14 @@ class ConfigEditorDialog(QtWidgets.QDialog):
             else:
                 # Create appropriate widget for the value
                 is_readonly = full_key in self.readonly_keys
-                widget = self._create_widget(value, is_readonly)
+                widget = self._create_widget(value, is_readonly, key)
                 self.field_widgets[full_key] = (widget, value)
+                
+                # Connect signal for dataset matching info updates
+                if self.block_name == 'dataset' and self.file_map and self.subjects:
+                    if key in ['subjects_to_exclude', 'task']:
+                        if isinstance(widget, QtWidgets.QLineEdit):
+                            widget.textChanged.connect(self._update_matching_info)
                 
                 # Create label with tooltip if available
                 label = QtWidgets.QLabel(f"{key}:")
@@ -116,7 +136,7 @@ class ConfigEditorDialog(QtWidgets.QDialog):
                 
                 self.form_layout.addRow(label, widget)
     
-    def _create_widget(self, value, readonly=False):
+    def _create_widget(self, value, readonly=False, key=None):
         """Create appropriate widget based on value type"""
         if isinstance(value, bool):
             widget = QtWidgets.QCheckBox()
@@ -171,6 +191,68 @@ class ConfigEditorDialog(QtWidgets.QDialog):
             widget.setStyleSheet("background-color: #f0f0f0;")
         
         return widget
+    
+    def _update_matching_info(self):
+        """Calculate and display matching subjects/runs based on current form values"""
+        if not self.matching_info_label or not self.file_map or not self.subjects:
+            return
+        
+        try:
+            # Get current values from widgets
+            subjects_to_exclude_text = ""
+            task_text = ""
+            
+            for key, (widget, _) in self.field_widgets.items():
+                if 'subjects_to_exclude' in key and isinstance(widget, QtWidgets.QLineEdit):
+                    subjects_to_exclude_text = widget.text().strip()
+                elif key == 'task' and isinstance(widget, QtWidgets.QLineEdit):
+                    task_text = widget.text().strip()
+            
+            # Parse subjects_to_exclude (comma-separated list with optional quotes/brackets)
+            excluded_subjects = set()
+            if subjects_to_exclude_text:
+                # Remove brackets if present (handles ["01", "02"] format)
+                text = subjects_to_exclude_text.strip().strip('[]')
+                # Split by comma and clean up each item
+                for s in text.split(','):
+                    s = s.strip().strip('"\'').strip()
+                    if s:
+                        # Add "sub-" prefix if not already present
+                        if not s.startswith('sub-'):
+                            s = f"sub-{s}"
+                        excluded_subjects.add(s)
+            
+            print(f"DEBUG: Parsed excluded_subjects: {excluded_subjects}")
+            
+            # Calculate matching subjects
+            all_subjects = set(self.subjects)
+            matching_subjects = all_subjects - excluded_subjects
+            num_matching_subjects = len(matching_subjects)
+            
+            # Calculate matching runs based on task pattern
+            # Count runs in file_map that match the task for non-excluded subjects
+            num_matching_runs = 0
+            if task_text:  # Only count if task is specified
+                for subject in matching_subjects:
+                    if subject in self.file_map:
+                        for run in self.file_map[subject].keys():
+                            # Check if run matches task pattern
+                            if f"task-{task_text}" in run:
+                                num_matching_runs += 1
+            
+            # Format and display the information
+            info_text = (
+                f"<b>📊 Pipeline Scope:</b><br>"
+                f"• <b>{num_matching_subjects}</b> subjects will be included "
+                f"(out of {len(all_subjects)} total)<br>"
+                f"• <b>{num_matching_runs}</b> runs match the task pattern"
+            )
+            
+            self.matching_info_label.setText(info_text)
+            
+        except Exception as e:
+            print(f"Error updating matching info: {e}")
+            self.matching_info_label.setText("⚠️ Error calculating matches")
     
     def get_updated_data(self):
         """Extract updated values from form widgets"""
@@ -2751,8 +2833,14 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             # Extract field tooltips from comments
             field_tooltips = self._extract_field_comments(original_lines, block_name)
             
-            # Open editor dialog
-            dialog = ConfigEditorDialog(block_data, block_name, readonly_keys, field_tooltips, self)
+            # Open editor dialog with file_map and subjects if editing dataset block
+            if block_name == 'dataset':
+                dialog = ConfigEditorDialog(
+                    block_data, block_name, readonly_keys, field_tooltips, self,
+                    file_map=self.file_map, subjects=self.subjects
+                )
+            else:
+                dialog = ConfigEditorDialog(block_data, block_name, readonly_keys, field_tooltips, self)
             
             if dialog.exec() == QtWidgets.QDialog.Accepted:
                 # Get updated data

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -6103,14 +6103,14 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             return False
     
     def _start_pipeline_monitoring(self):
-        """Start the QTimer to monitor file updates every 30 seconds"""
+        """Start the QTimer to monitor file updates every 5 seconds"""
         if self.pipeline_monitor_timer is None:
             self.pipeline_monitor_timer = QtCore.QTimer(self)
             self.pipeline_monitor_timer.timeout.connect(self._check_file_updates)
         
-        # Check immediately, then every 30 seconds
+        # Check immediately, then every 5 seconds
         self._check_file_updates()
-        self.pipeline_monitor_timer.start(30000)  # 30 seconds
+        self.pipeline_monitor_timer.start(5000)  # 5 seconds
         
         self.statbar.showMessage("Pipeline monitoring active...")
     
@@ -6232,7 +6232,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 self._mark_updated_files_for_reload(files_changed_to_black)
                 
                 # Auto-reload if currently displayed file just completed
-                # NOTE: This only triggers ONCE when file status changes to black, not every 30 seconds
+                # NOTE: This only triggers ONCE when file status changes to black, not every 5 seconds
                 # files_changed_to_black only contains files that changed THIS update cycle
                 current_subj = self.subj.currentText() if hasattr(self, 'subj') else None
                 current_run = self.run.currentText() if hasattr(self, 'run') else None

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -1807,16 +1807,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         
         # Note: HbO/HbR selection uses the wavelength/chromophore list widget below (wv)
         # No separate checkboxes needed for HRF view
-        
-        # Add file type filter for color coding
-        hrf_checkbox_layout.addWidget(QtWidgets.QLabel("  |  Color by:"))
-        self.color_file_type = QtWidgets.QComboBox()
-        self.color_file_type.addItems(["Preprocessing", "HRF Estimate", "Image Recon", "All (any complete)"])
-        self.color_file_type.setCurrentText("Preprocessing")
-        self.color_file_type.setToolTip("Choose which file type to check for color coding status")
-        self.color_file_type.currentTextChanged.connect(self._color_file_type_changed)
-        self.color_file_type.setMinimumWidth(150)
-        hrf_checkbox_layout.addWidget(self.color_file_type)
+        # Color coding is automatic: Preprocessing when HRF view off, HRF Estimate when HRF view on
         
         # Add separator
         separator = QtWidgets.QFrame()
@@ -3886,23 +3877,6 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             # Save GUI state after HRF group average change
             self._save_gui_state()
     
-    def _color_file_type_changed(self):
-        """Handle changes to color file type filter - update all file colors"""
-        print(f"DEBUG: Color file type changed to: {self.color_file_type.currentText()}")
-        if self.snakemake_config:
-            self._update_all_file_colors()
-            # Force comboboxes to repaint
-            if hasattr(self, 'subj'):
-                self.subj.repaint()
-                if self.subj.view():
-                    self.subj.view().repaint()
-            if hasattr(self, 'run'):
-                self.run.repaint()
-                if self.run.view():
-                    self.run.view().repaint()
-            self._update_combobox_selection_colors()
-            self.statbar.showMessage(f"Color coding now based on: {self.color_file_type.currentText()}")
-    
     def _launch_plot_probe(self):
         """Launch the Plot Probe GUI with current HRF data"""
         print("Launching Plot Probe GUI...")
@@ -4007,7 +3981,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         
         # Import and launch the plot_probe_gui
         try:
-            from cedalion.vis.misc.plot_probe_gui import _MAIN_GUI
+            from plot_probe_gui import _MAIN_GUI
             print(f"Launching with HRF data dims: {blockaverage.dims}")
             if stderr is not None:
                 print(f"Passing stderr with dims: {stderr.dims}")
@@ -6394,7 +6368,49 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             # Apply subject color once
             self._apply_subject_color_to_combobox(subject, subject_color)
         
+        # Update image reconstruction button color based on current selection
+        self._update_image_recon_button_color()
+        
         return files_changed_to_black
+    
+    def _update_image_recon_button_color(self):
+        """Update the Image Reconstruction button text color based on file status"""
+        if not hasattr(self, 'image_recon_btn'):
+            return
+        
+        # Get current selection
+        current_subject = self.subj.currentText() if hasattr(self, 'subj') else None
+        current_run = self.run.currentText() if hasattr(self, 'run') else None
+        
+        if not current_subject or not current_run or current_subject == "None" or current_run == "None":
+            # No selection, reset to default
+            self.image_recon_btn.setStyleSheet("")
+            return
+        
+        # Get the image recon file path for current selection
+        file_path = self._get_image_recon_file_path(current_subject, current_run)
+        
+        if not file_path or file_path not in self.current_scope_files:
+            # File not in scope, gray (use default styling)
+            self.image_recon_btn.setStyleSheet("color: gray;")
+            return
+        
+        # Get status info
+        status_info = self.current_scope_files[file_path]
+        status = status_info.get('status', '')
+        plan = status_info.get('plan', '')
+        is_up_to_date = (status == 'ok' and 'no update' in plan.lower())
+        
+        # Determine color
+        if is_up_to_date:
+            color = 'black'  # File complete
+        elif self._is_pipeline_running():
+            color = 'orange'  # Pipeline working on it
+        else:
+            color = 'red'  # Needs work, pipeline not running
+        
+        # Apply color to button text
+        self.image_recon_btn.setStyleSheet(f"color: {color}; font-weight: bold;")
     
     def _is_pipeline_running(self):
         """Check if the Snakemake pipeline is currently running"""
@@ -6433,8 +6449,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         - Non-selected file, needs update: Red (needs work but skipping)
         - Gray: File not in GUI config at all
         """
-        # Determine which file(s) to check based on color_file_type selector
-        color_by = self.color_file_type.currentText() if hasattr(self, 'color_file_type') else "Preprocessing"
+        # Automatically determine color coding mode based on HRF view state
+        # When HRF view is active, check HRF estimate files; otherwise check preprocessing files
+        color_by = "HRF Estimate" if (hasattr(self, 'hrf_view') and self.hrf_view.isChecked()) else "Preprocessing"
         
         file_paths_to_check = []
         
@@ -6448,16 +6465,6 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             file_type = "image reconstruction"
             if file_path:
                 file_paths_to_check.append(file_path)
-        elif color_by == "All (any complete)":
-            # Check all three file types
-            file_type = "any (preprocess/HRF/image)"
-            for path in [
-                self._get_preprocessing_file_path(subject, run),
-                self._get_expected_file_path(subject, run),
-                self._get_image_recon_file_path(subject, run)
-            ]:
-                if path:
-                    file_paths_to_check.append(path)
         else:  # Default: "Preprocessing"
             file_path = self._get_preprocessing_file_path(subject, run)
             file_type = "preprocessing"
@@ -6470,39 +6477,6 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         if not file_paths_to_check:
             print(f"DEBUG: Could not determine {file_type} path(s), returning gray")
             return 'gray'
-        
-        # For "All" mode, check if ANY file is in scope and up-to-date
-        if color_by == "All (any complete)":
-            any_in_scope = False
-            any_up_to_date = False
-            any_needs_update = False
-            
-            for file_path in file_paths_to_check:
-                if file_path in self.current_scope_files:
-                    any_in_scope = True
-                    status_info = self.current_scope_files[file_path]
-                    status = status_info.get('status', '')
-                    plan = status_info.get('plan', '')
-                    is_up_to_date = (status == 'ok' and 'no update' in plan.lower())
-                    
-                    if is_up_to_date:
-                        any_up_to_date = True
-                    else:
-                        any_needs_update = True
-            
-            if not any_in_scope:
-                print(f"DEBUG: No files in current scope, returning gray")
-                return 'gray'
-            
-            if any_up_to_date:
-                print(f"DEBUG: At least one file up to date, returning black")
-                return 'black'
-            elif any_needs_update:
-                color = 'orange' if self._is_pipeline_running() else 'red'
-                print(f"DEBUG: All files need update, returning {color}")
-                return color
-            else:
-                return 'gray'
         
         # Single file mode - check the specific file
         file_path = file_paths_to_check[0]
@@ -6912,6 +6886,9 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 run_color = self.file_colors.get((current_subj, current_run))
                 if run_color:
                     self.run.setStyleSheet(f"QComboBox {{ color: {color_map[run_color]}; }}")
+        
+        # Update image reconstruction button color for current selection
+        self._update_image_recon_button_color()
     
     def _apply_color_to_combobox(self, subject, run, color):
         """Apply color styling to combobox items for subject/run"""

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -1288,6 +1288,10 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self.current_selection_subject = None  # Subject ID (e.g., "15")
         self.current_selection_task = None  # Task name (e.g., "IWHD")
         self.current_selection_run = None  # Run ID (e.g., "01")
+        
+        # Axis zoom preservation
+        self.preserved_xlim = None  # Store x-axis limits
+        self.preserved_ylim = None  # Store y-axis limits
 
         self._UI_SETUP()
         
@@ -1718,6 +1722,10 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self.plots.mpl_connect("key_press_event", self._shift_is_pressed)
         self.plots.mpl_connect("key_release_event", self._shift_is_released)
         self.plots.mpl_connect("pick_event", self._optode_picked)
+        
+        # Connect axis limit change event for zoom preservation
+        self._dataTimeSeries_ax.callbacks.connect('xlim_changed', self._on_xlims_change)
+        self._dataTimeSeries_ax.callbacks.connect('ylim_changed', self._on_xlims_change)
 
         # Create Control Panel
         control_panel = QtWidgets.QGroupBox("Control Panel")
@@ -1882,6 +1890,13 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self.opt2circ = QtWidgets.QCheckBox("View optodes as circles")
         self.opt2circ.stateChanged.connect(self._toggle_circles)
         opt_layout.addWidget(self.opt2circ)
+        
+        ## Create Preserve Axis Zoom Checkbox
+        self.preserve_axis_zoom = QtWidgets.QCheckBox("Preserve Axis Zoom")
+        self.preserve_axis_zoom.setChecked(False)
+        self.preserve_axis_zoom.setToolTip("Keep current axis zoom when switching measurements, subjects, or wavelengths")
+        self.preserve_axis_zoom.stateChanged.connect(self._preserve_zoom_changed)
+        opt_layout.addWidget(self.preserve_axis_zoom)
 
         ## Create Stimulus Selection Dropdown with checkboxes
         stim_label = QtWidgets.QLabel("Stimuli:")
@@ -3403,6 +3418,27 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             self.optodes.set_visible(False)
 
         self._optode_ax.figure.canvas.draw()
+    
+    def _preserve_zoom_changed(self):
+        """Handle preserve axis zoom checkbox state change"""
+        if self.preserve_axis_zoom.isChecked():
+            # Save current axis limits when checkbox is enabled
+            self.preserved_xlim = self._dataTimeSeries_ax.get_xlim()
+            self.preserved_ylim = self._dataTimeSeries_ax.get_ylim()
+            print(f"Preserve zoom enabled. Saved limits: x={self.preserved_xlim}, y={self.preserved_ylim}")
+        else:
+            # Clear saved limits when checkbox is disabled
+            self.preserved_xlim = None
+            self.preserved_ylim = None
+            print("Preserve zoom disabled. Cleared saved limits.")
+    
+    def _on_xlims_change(self, event_ax):
+        """Callback when axis limits change (e.g., after zooming)"""
+        if self.preserve_axis_zoom.isChecked() and event_ax == self._dataTimeSeries_ax:
+            # Update preserved limits when user zooms
+            self.preserved_xlim = self._dataTimeSeries_ax.get_xlim()
+            self.preserved_ylim = self._dataTimeSeries_ax.get_ylim()
+            print(f"Axis limits updated: x={self.preserved_xlim}, y={self.preserved_ylim}")
 
     def _toggle_hrf_view(self):
         """Toggle between time series and HRF display"""
@@ -4511,8 +4547,16 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self._optode_ax.figure.canvas.draw()
 
     def _draw_timeseries(self):
-
+        # Save current axis limits before clearing
         xxlim = self._dataTimeSeries_ax.get_xlim()
+        yylim = self._dataTimeSeries_ax.get_ylim()
+        
+        # If preserve zoom is enabled and we have saved limits, use those
+        if self.preserve_axis_zoom.isChecked():
+            if self.preserved_xlim is not None:
+                xxlim = self.preserved_xlim
+            if self.preserved_ylim is not None:
+                yylim = self.preserved_ylim
 
         self._dataTimeSeries_ax.clear()
 
@@ -4531,9 +4575,11 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self.t = self.snirfData.time.values
         
         # Check if we need to reset xlim (e.g., switching from HRF view or initial load)
-        # If the saved xlim is outside the time series data range, reset it
-        if xxlim[1] < self.t[-1] * 0.5 or xxlim[0] < 0 or xxlim[1] > self.t[-1]:
-            xxlim = (0, 1)  # This will trigger auto-scaling later
+        # Skip this check if preserve axis zoom is enabled
+        if not self.preserve_axis_zoom.isChecked():
+            # If the saved xlim is outside the time series data range, reset it
+            if xxlim[1] < self.t[-1] * 0.5 or xxlim[0] < 0 or xxlim[1] > self.t[-1]:
+                xxlim = (0, 1)  # This will trigger auto-scaling later
 
         # Use unified channel selection - convert indices to channel names
         chan_sel = [self.snirfData.channel.values[i] for i in self.selected_channels 
@@ -4770,9 +4816,16 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self._dataTimeSeries_ax.set_ylabel(ylabel)
         self._dataTimeSeries_ax.grid("True", axis="y")
 
-        # set the xlim if desired
-        if xxlim[0] != 0 and xxlim[1] != 1:
-            self._dataTimeSeries_ax.set_xlim(xxlim)
+        # Set axis limits if preserve zoom is enabled or if we have non-default xlim
+        if self.preserve_axis_zoom.isChecked():
+            if xxlim[0] != 0 or xxlim[1] != 1:
+                self._dataTimeSeries_ax.set_xlim(xxlim)
+            if yylim[0] != 0 or yylim[1] != 1:
+                self._dataTimeSeries_ax.set_ylim(yylim)
+        else:
+            # Original behavior - only preserve xlim
+            if xxlim[0] != 0 or xxlim[1] != 1:
+                self._dataTimeSeries_ax.set_xlim(xxlim)
 
         self._dataTimeSeries_ax.figure.canvas.draw()
 

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -2349,131 +2349,64 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 print(f"DEBUG: Run on current selection only mode enabled")
                 print(f"  Selected: sub-{self.current_selection_subject}, task-{self.current_selection_task}, run-{self.current_selection_run}")
                 
-                # Create a temporary config file with overrides using text-based approach
-                # This preserves all config sections, comments, and formatting
+                # Create a temporary config file with overrides
+                # This preserves nested config structure which command-line args cannot handle
                 if config_path and os.path.exists(config_path):
                     try:
-                        # Read original config as text to preserve formatting
+                        # Load config as dictionary
+                        import yaml
                         with open(config_path, 'r', encoding='utf-8') as f:
-                            config_text = f.read()
+                            config_data = yaml.safe_load(f)
                         
                         print(f"DEBUG: Creating temp config from: {config_path}")
                         
-                        # Replace subject value using regex (handles both inline and block formats)
-                        if subject_match:
-                            subject_id = subject_match.group(1)
-                            # Try inline format first: subject: [item1, item2]
-                            if re.search(r'subject:\s*\[', config_text):
-                                config_text = re.sub(
-                                    r'(subject:\s*\[)[^\]]*(\])',
-                                    rf'\g<1>"{subject_id}"\g<2>',
-                                    config_text
-                                )
-                                print(f"DEBUG: Replaced subject with [\"{subject_id}\"] (inline format)")
-                            # Try block format: subject:\n  - item1
-                            elif re.search(r'subject:\s*\n', config_text):
-                                config_text = re.sub(
-                                    r'(subject:)\s*\n(\s*-\s*[^\n]+\n)*',
-                                    rf'\g<1>\n  - "{subject_id}"\n',
-                                    config_text
-                                )
-                                print(f"DEBUG: Replaced subject with - \"{subject_id}\" (block format)")
-                        
-                        # Replace task value using regex
+                        # Override task with single-item list
                         if task_match:
                             task_id = task_match.group(1)
-                            # Try inline format first
-                            if re.search(r'task:\s*\[', config_text):
-                                config_text = re.sub(
-                                    r'(task:\s*\[)[^\]]*(\])',
-                                    rf'\g<1>"{task_id}"\g<2>',
-                                    config_text
-                                )
-                                print(f"DEBUG: Replaced task with [\"{task_id}\"] (inline format)")
-                            # Try block format
-                            elif re.search(r'task:\s*\n', config_text):
-                                config_text = re.sub(
-                                    r'(task:)\s*\n(\s*-\s*[^\n]+\n)*',
-                                    rf'\g<1>\n  - "{task_id}"\n',
-                                    config_text
-                                )
-                                print(f"DEBUG: Replaced task with - \"{task_id}\" (block format)")
+                            config_data['dataset']['task'] = [task_id]
+                            print(f"DEBUG: Override task=['{task_id}']")
                         
-                        # Replace run value using regex
+                        # Override run with single-item list
                         if run_match:
                             run_id = run_match.group(1)
-                            # Try inline format first
-                            if re.search(r'run:\s*\[', config_text):
-                                config_text = re.sub(
-                                    r'(run:\s*\[)[^\]]*(\])',
-                                    rf'\g<1>"{run_id}"\g<2>',
-                                    config_text
-                                )
-                                print(f"DEBUG: Replaced run with [\"{run_id}\"] (inline format)")
-                            # Try block format
-                            elif re.search(r'run:\s*\n', config_text):
-                                config_text = re.sub(
-                                    r'(run:)\s*\n(\s*-\s*[^\n]+\n)*',
-                                    rf'\g<1>\n  - "{run_id}"\n',
-                                    config_text
-                                )
-                                print(f"DEBUG: Replaced run with - \"{run_id}\" (block format)")
+                            config_data['dataset']['run'] = [run_id]
+                            print(f"DEBUG: Override run=['{run_id}']")
                         
-                        # Set num_runs to 1 since we're running single run only
-                        config_text = re.sub(
-                            r'(num_runs:\s*)\d+',
-                            r'\g<1>1',
-                            config_text
-                        )
-                        print(f"DEBUG: Set num_runs to 1 for current selection only mode")
+                        # Set run_list to match the single run (replaces num_runs approach)
+                        if run_match:
+                            config_data['dataset']['run_list'] = [run_id]
+                            print(f"DEBUG: Set run_list=['{run_id}']")
                         
                         # Set subjects_to_exclude to all subjects except the current one
                         if subject_match:
                             subject_id = subject_match.group(1)
-                            try:
-                                # Load config to get root_dir
-                                import yaml
-                                with open(config_path, 'r', encoding='utf-8') as f:
-                                    config_data = yaml.safe_load(f)
-                                root_dir = config_data.get('dataset', {}).get('root_dir', '')
+                            root_dir = config_data.get('dataset', {}).get('root_dir', '')
+                            
+                            # Find all sub-* directories in root_dir
+                            if root_dir and os.path.exists(root_dir):
+                                all_subjects = []
+                                for item in os.listdir(root_dir):
+                                    if item.startswith('sub-') and os.path.isdir(os.path.join(root_dir, item)):
+                                        # Extract subject ID (without "sub-" prefix)
+                                        sub_id = item.replace('sub-', '')
+                                        all_subjects.append(sub_id)
                                 
-                                # Find all sub-* directories in root_dir
-                                if root_dir and os.path.exists(root_dir):
-                                    all_subjects = []
-                                    for item in os.listdir(root_dir):
-                                        if item.startswith('sub-') and os.path.isdir(os.path.join(root_dir, item)):
-                                            # Extract subject ID (without "sub-" prefix)
-                                            sub_id = item.replace('sub-', '')
-                                            all_subjects.append(sub_id)
-                                    
-                                    # Exclude all subjects except current one
-                                    subjects_to_exclude = [s for s in all_subjects if s != subject_id]
-                                    if subjects_to_exclude:
-                                        # Replace subjects_to_exclude in config
-                                        exclude_str = ', '.join([f'"{s}"' for s in subjects_to_exclude])
-                                        config_text = re.sub(
-                                            r'(subjects_to_exclude:\s*)\[[^\]]*\]',
-                                            rf'\g<1>[{exclude_str}]',
-                                            config_text
-                                        )
-                                        print(f"DEBUG: Set subjects_to_exclude to exclude all except {subject_id}: {subjects_to_exclude}")
-                            except Exception as e:
-                                print(f"WARNING: Could not update subjects_to_exclude: {e}")
+                                # Exclude all subjects except current one
+                                subjects_to_exclude = [s for s in all_subjects if s != subject_id]
+                                config_data['dataset']['subjects_to_exclude'] = subjects_to_exclude
+                                print(f"DEBUG: Set subjects_to_exclude to exclude all except {subject_id}: {subjects_to_exclude}")
                         
-                        # Write temporary config file (for snakemake execution ONLY)
-                        # Save in same directory as original config instead of temp folder
+                        # Write temporary config file
+                        # Save in same directory as original config
                         config_dir = os.path.dirname(config_path)
                         temp_config_path = os.path.join(config_dir, 'snakemake_config_temp.yaml')
                         with open(temp_config_path, 'w', encoding='utf-8') as f:
-                            f.write(config_text)
+                            yaml.dump(config_data, f, default_flow_style=False, sort_keys=False)
                         
-                        # Store original config path for monitoring (before overwriting)
+                        # Store original config path for monitoring
                         original_config_path = config_path
-                        # Store as instance variable so monitoring can access it
-                        self.snakemake_config_path_original = original_config_path
                         config_path = temp_config_path  # Use temp config for execution
                         print(f"DEBUG: Created temp config at: {config_path}")
-                        print(f"DEBUG: Original config preserved for monitoring: {original_config_path}")
                         
                     except Exception as e:
                         print(f"ERROR: Config override failed: {e}")
@@ -2537,8 +2470,8 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                         print(f"STDERR: {unlock_result.stderr[:200]}")
                     
                     # Now run summary to get status of all workflow files
-                    # When running "current selection only", use temp config for summary too
-                    # so it only detects files for the current selection
+                    # When running "current selection only", use temp config for summary
+                    # This ensures summary only detects files for the current selection
                     summary_config = config_path  # Use same config as execution (temp if current selection only)
                     config_type = "temp (current selection)" if run_current_only else "full"
                     print(f"Running summary for {config_type} config scope...")
@@ -2619,7 +2552,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                         
                         # Only monitor actual pipeline runs, not dry runs or summaries
                         if not dry_run and not show_summary:
-                            # Store the actual config path used (temp or original) for process detection
+                            # Store the actual config path used (temp or original) for monitoring
                             self._actual_config_used = config_path
                             
                             # Wait for snakemake process to start with retries
@@ -5827,12 +5760,15 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             return
         
         try:
-            # Run summary for current config scope only
+            # Run summary using the actual config file (no temp config needed)
+            # The config file already has the correct subjects configured
             print("Running summary for current config scope...")
             self.current_scope_files = self._run_snakemake_summary(
                 self.snakefile_path,
-                self.snakemake_config_path
+                self.snakemake_config_path,
+                target_rule='all_imagerecon'  # Use all_imagerecon to get individual subject files
             )
+            
             print(f"  ✓ Loaded status for {len(self.current_scope_files)} files in current config")
             
             # No need for full scope summary - files not in current scope will be gray
@@ -5864,6 +5800,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 cmd = ['snakemake', '-s', snakefile_path, '--configfile', config_path, '--nolock', '--summary', target_rule]
             
             print(f"DEBUG: Running summary command: {' '.join(cmd)}")
+
             
             # Run the summary command
             result = subprocess.run(
@@ -6151,13 +6088,13 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         
         try:
             # Determine which config to use for monitoring
-            # In "run current only" mode, monitor only the temp config (file being processed)
-            # Use the actual config that was used for execution (temp or original)
+            # In "run current only" mode, use the temp config
             monitor_config = getattr(self, '_actual_config_used', self.snakemake_config_path)
+            
             if self.run_current_only_mode:
-                print(f"DEBUG: Monitoring temp config (selected file only): {monitor_config}")
+                print(f"DEBUG: Monitoring with temp config (selected file only): {monitor_config}")
             else:
-                print(f"DEBUG: Monitoring with current config: {monitor_config}")
+                print(f"DEBUG: Monitoring with current config (full pipeline)")
             
             # Reload config file to pick up any changes
             with open(monitor_config, 'r') as f:
@@ -6539,8 +6476,11 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         else:
             color = 'red'  # Needs work, pipeline not running
         
-        # Apply color to button text
-        self.image_recon_btn.setStyleSheet(f"color: {color}; font-weight: bold;")
+        # Apply color to button text (bold only for non-black)
+        if color == 'black':
+            self.image_recon_btn.setStyleSheet(f"color: {color};")
+        else:
+            self.image_recon_btn.setStyleSheet(f"color: {color}; font-weight: bold;")
     
     def _is_pipeline_running(self):
         """Check if the Snakemake pipeline is currently running"""
@@ -6811,23 +6751,71 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             return None
         
         try:
+            import yaml
             config_dir = os.path.dirname(self.snakemake_config_path)
+            
+            # Load config to get image_recon parameters
+            with open(self.snakemake_config_path, 'r') as f:
+                config = yaml.safe_load(f)
             
             # Extract task name from run (e.g., "task-STS_run-01" -> "STS")
             task = run.split('task-')[1].split('_')[0] if 'task-' in run else 'unknown'
-            run_num = run.split('run-')[1] if 'run-' in run else '01'
+            
+            # Extract subject number (e.g., "sub-752" -> "752")
+            subj_num = subject.split('-')[1] if '-' in subject else subject
+            
+            # Build filename matching Snakefile's get_imagerecon_output() function
+            img_cfg = config.get('image_recon', {})
+            
+            # Get alpha values and convert to string (handle both string and numeric types from YAML)
+            alpha_spatial = img_cfg.get('alpha_spatial', '1e-3')
+            alpha_meas = img_cfg.get('alpha_meas', '1e4')
+            # Convert to string as-is if string, otherwise use default string conversion
+            alpha_spatial_str = str(alpha_spatial)
+            alpha_meas_str = str(alpha_meas)
+            
+            filename = (
+                f"Xs_sub-{subj_num}_{task}"
+                f"_cov_alpha_spatial_{alpha_spatial_str}"
+                f"_alpha_meas_{alpha_meas_str}"
+                f"_recon_mode_{img_cfg.get('recon_mode', 'mua2conc')}"
+                f"{'_Cmeas' if img_cfg.get('Cmeas', {}).get('enable', False) else '_noCmeas'}"
+                f"{'_SB' if img_cfg.get('spatial_basis', {}).get('enable', False) else '_noSB'}"
+                f"{'_mag' if img_cfg.get('mag', {}).get('enable', False) else '_ts'}"
+            )
+            
+            # Add time window if mag is enabled
+            if img_cfg.get('mag', {}).get('enable', False):
+                t_win = img_cfg.get('mag', {}).get('t_win', [5, 8])
+                filename += f"_{t_win[0]}_{t_win[1]}"
+            
+            filename += ".nc"
             
             # Image reconstruction file path (individual subject):
-            # derivatives/cedalion/XXX/image_results/sub-10/Xs_sub-10_task-STS_run-01.nc
             file_path = os.path.join(
                 config_dir,
                 'image_results',
                 subject,
-                f"Xs_{subject}_task-{task}_run-{run_num}.nc"
+                filename
             )
             
             # Normalize to match summary output format
             file_path = os.path.normpath(file_path)
+            
+            print(f"DEBUG _get_image_recon_file_path: Constructed path: {file_path}")
+            print(f"DEBUG _get_image_recon_file_path: Filename: {filename}")
+            print(f"DEBUG _get_image_recon_file_path: current_scope_files has {len(self.current_scope_files) if hasattr(self, 'current_scope_files') else 0} entries")
+            print(f"DEBUG _get_image_recon_file_path: Path exists in summary: {file_path in self.current_scope_files if hasattr(self, 'current_scope_files') else 'N/A'}")
+            if hasattr(self, 'current_scope_files') and len(self.current_scope_files) > 0:
+                # Show ALL paths in the summary for debugging
+                all_paths = list(self.current_scope_files.keys())
+                print(f"DEBUG _get_image_recon_file_path: All paths in summary: {all_paths}")
+                # Show matching paths in the summary
+                matching = [p for p in self.current_scope_files.keys() if 'image_results' in p and subject in p]
+                if matching:
+                    print(f"DEBUG _get_image_recon_file_path: Matching image paths in summary: {matching[:2]}")
+                else:
+                    print(f"DEBUG _get_image_recon_file_path: NO matching image_results paths found for {subject}")
             
             return file_path
             

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -5025,7 +5025,13 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
 
         wvl_idx = self.wv.selectedItems()
         wvl_idx = [foo.text() for foo in wvl_idx]
-        wvl_ls = ["-", ":"]
+        
+        # Use solid line if only one wavelength/chromophore selected, 
+        # otherwise use solid and dotted to distinguish them
+        if len(wvl_idx) == 1:
+            wvl_ls = ["-"]  # Only solid line
+        else:
+            wvl_ls = ["-", ":"]  # Solid and dotted
 
         ## Grab timeseries y-label
         ylabel = self.ts_sel
@@ -5081,10 +5087,10 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
 
         # Plot timeseries
         if "wavelength" in self.snirfData.dims:
-            for sel_wv in wvl_idx:
-                idx = self.snirfData.wavelength.values
-                idx = [str(foo) for foo in idx]
-                idx = idx.index(sel_wv)
+            for i_wv, sel_wv in enumerate(wvl_idx):
+                # Use index within selected wavelengths for line style
+                ls_idx = i_wv % len(wvl_ls) if len(wvl_ls) > 1 else 0
+                
                 for i_ch, chan in enumerate(nempty_chan_sel):
                     # Get the actual channel index for consistent coloring
                     chan_idx = np.where(self.snirfData.channel.values == chan)[0][0]
@@ -5099,7 +5105,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                     self.timeSeries = self._dataTimeSeries_ax.plot(
                         self.t,
                         self.snirfData.sel(channel=chan, wavelength=sel_wv).T,
-                        ls=wvl_ls[idx],
+                        ls=wvl_ls[ls_idx],
                         zorder=5,
                         color=chan_col[color_idx],
                     )
@@ -5122,11 +5128,10 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                     )
 
         elif "chromo" in self.snirfData.dims:
-            for sel_wv in wvl_idx:
-                idx = self.snirfData.chromo.values
-                idx = [str(foo) for foo in idx]
-                idx = idx.index(sel_wv[1:-1])
-
+            for i_wv, sel_wv in enumerate(wvl_idx):
+                # Use index within selected chromophores for line style
+                ls_idx = i_wv % len(wvl_ls) if len(wvl_ls) > 1 else 0
+                
                 if "[" in sel_wv:
                     sel_wv = sel_wv[1:-1]
 
@@ -5144,7 +5149,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                     self.timeSeries = self._dataTimeSeries_ax.plot(
                         self.t,
                         self.snirfData.sel(channel=chan, chromo=sel_wv).T,
-                        ls=wvl_ls[idx],
+                        ls=wvl_ls[ls_idx],
                         zorder=5,
                         color=chan_col[color_idx],
                     )
@@ -5341,11 +5346,6 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8", "#F7DC6F", "#BB8FCE", "#85C1E9", "#F8C471"
         ]
         
-        # Get selected wavelength/chromo
-        wvl_idx = self.wv.selectedItems()
-        wvl_idx = [foo.text() for foo in wvl_idx]
-        wvl_ls = ["-", ":"]
-        
         # Get trial types from HRF data
         trial_types = hrf_est.coords['trial_type'].values
         
@@ -5380,6 +5380,13 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             return
         
         print(f"Plotting HRF - Trial types: {trial_types}, Chromos: {selected_chromos}, Group avg: {self.hrf_group_avg.isChecked()}")
+        
+        # Define line styles for chromophores
+        # Use solid if only one chromophore selected, otherwise alternate solid/dotted
+        if len(selected_chromos) == 1:
+            chromo_ls = {selected_chromos[0]: '-'}  # Only solid line
+        else:
+            chromo_ls = {'HbO': '-', 'HbR': ':'}  # Solid for HbO, dotted for HbR
         
         ymin = 100
         ymax = -100
@@ -5420,24 +5427,29 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                                 # Extract HRF data for this channel, trial type, and chromo
                                 hrf_values = hrf_est.sel(channel=channel, trial_type=trial_type, chromo=chromo_name).values
                                 
-                                # Set style based on chromophore
-                                if chromo_name == 'HbO':
-                                    linewidth = 2.5  # Thicker for HbO
-                                    alpha = 0.9      # More opaque
-                                    marker_style = ''  # No marker for HbO
-                                    marker_size = 0
-                                else:  # HbR
-                                    linewidth = 1.5  # Thinner for HbR
-                                    alpha = 0.8      # Slightly more transparent
-                                    marker_style = 'o' if marker else ''  # Add small markers for HbR
-                                    marker_size = 3
+                                # Get line style for this chromophore
+                                chromo_line_style = chromo_ls.get(chromo_name, '-')
+                                
+                                # Combine stimulus line style with chromophore style
+                                # For multiple stimuli, vary the dash pattern
+                                if len(trial_types) == 1:
+                                    combined_line_style = chromo_line_style
+                                else:
+                                    # Use chromophore style as base, add stimulus distinction if needed
+                                    combined_line_style = line_style if chromo_line_style == '-' else chromo_line_style
+                                
+                                # Set consistent styling
+                                linewidth = 2.0
+                                alpha = 0.85
+                                marker_style = marker if marker else ''
+                                marker_size = 3 if marker else 0
                                 
                                 # Plot with label showing channel, trial type and chromo
                                 label = f"{chromo_name}-{trial_type}-{channel}"
                                 self._dataTimeSeries_ax.plot(
                                     hrf_time,
                                     hrf_values,
-                                    ls=line_style,
+                                    ls=combined_line_style,
                                     marker=marker_style,
                                     markersize=marker_size,
                                     markevery=5,  # Only show markers every 5 points to avoid clutter
@@ -5481,24 +5493,29 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                                 # Extract HRF data for this channel, trial type, and chromo
                                 hrf_values = hrf_est.sel(trial_type=trial_type, channel=chan, chromo=chromo_name).values
                                 
-                                # Set style based on chromophore
-                                if chromo_name == 'HbO':
-                                    linewidth = 2.5  # Thicker for HbO
-                                    alpha = 0.9      # More opaque
-                                    marker_style = ''  # No marker for HbO
-                                    marker_size = 0
-                                else:  # HbR
-                                    linewidth = 1.5  # Thinner for HbR
-                                    alpha = 0.8      # Slightly more transparent
-                                    marker_style = 'o' if marker else ''  # Add small markers for HbR
-                                    marker_size = 3
+                                # Get line style for this chromophore
+                                chromo_line_style = chromo_ls.get(chromo_name, '-')
+                                
+                                # Combine stimulus line style with chromophore style
+                                # For multiple stimuli, vary the dash pattern
+                                if len(trial_types) == 1:
+                                    combined_line_style = chromo_line_style
+                                else:
+                                    # Use chromophore style as base, add stimulus distinction if needed
+                                    combined_line_style = line_style if chromo_line_style == '-' else chromo_line_style
+                                
+                                # Set consistent styling
+                                linewidth = 2.0
+                                alpha = 0.85
+                                marker_style = marker if marker else ''
+                                marker_size = 3 if marker else 0
                                 
                                 # Plot with label showing channel, trial type, and chromo
                                 label = f"{chan}-{chromo_name}-{trial_type}"
                                 self._dataTimeSeries_ax.plot(
                                     hrf_time,
                                     hrf_values,
-                                    ls=line_style,
+                                    ls=combined_line_style,
                                     marker=marker_style,
                                     markersize=marker_size,
                                     markevery=5,  # Only show markers every 5 points to avoid clutter

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -1965,6 +1965,14 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self.preserve_axis_zoom.setToolTip("Keep current axis zoom when switching measurements, subjects, or wavelengths")
         self.preserve_axis_zoom.stateChanged.connect(self._preserve_zoom_changed)
         opt_layout.addWidget(self.preserve_axis_zoom)
+        
+        ## Create Auto Scale Y-axis Checkbox (sub-option of Preserve Axis Zoom)
+        self.auto_scale_y = QtWidgets.QCheckBox("Auto scale Y-axis")
+        self.auto_scale_y.setChecked(False)
+        self.auto_scale_y.setEnabled(False)  # Disabled by default until preserve zoom is checked
+        self.auto_scale_y.setToolTip("Preserve X-axis zoom but auto-scale Y-axis for better amplitude visibility")
+        self.auto_scale_y.stateChanged.connect(self._save_gui_state)
+        opt_layout.addWidget(self.auto_scale_y)
 
         ## Create Stimulus Selection Dropdown with checkboxes
         stim_label = QtWidgets.QLabel("Stimuli:")
@@ -2797,6 +2805,10 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             if hasattr(self, 'preserve_axis_zoom'):
                 gui_state['preserve_axis_zoom'] = bool(self.preserve_axis_zoom.isChecked())
             
+            # Auto scale Y-axis checkbox state
+            if hasattr(self, 'auto_scale_y'):
+                gui_state['auto_scale_y'] = bool(self.auto_scale_y.isChecked())
+            
             # View optodes as circles checkbox state
             if hasattr(self, 'opt2circ'):
                 gui_state['opt2circ'] = bool(self.opt2circ.isChecked())
@@ -3004,7 +3016,17 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                     self.preserve_axis_zoom.blockSignals(True)
                     self.preserve_axis_zoom.setChecked(gui_state['preserve_axis_zoom'])
                     self.preserve_axis_zoom.blockSignals(False)
+                    # Enable/disable auto_scale_y based on preserve_axis_zoom state
+                    if hasattr(self, 'auto_scale_y'):
+                        self.auto_scale_y.setEnabled(gui_state['preserve_axis_zoom'])
                     print(f"  Restored preserve_axis_zoom: {gui_state['preserve_axis_zoom']}")
+                
+                # Restore auto scale Y-axis state
+                if 'auto_scale_y' in gui_state and hasattr(self, 'auto_scale_y'):
+                    self.auto_scale_y.blockSignals(True)
+                    self.auto_scale_y.setChecked(gui_state['auto_scale_y'])
+                    self.auto_scale_y.blockSignals(False)
+                    print(f"  Restored auto_scale_y: {gui_state['auto_scale_y']}")
                 
                 # Restore view optodes as circles state
                 if 'opt2circ' in gui_state and hasattr(self, 'opt2circ'):
@@ -3866,11 +3888,15 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             # Save current axis limits when checkbox is enabled
             self.preserved_xlim = self._dataTimeSeries_ax.get_xlim()
             self.preserved_ylim = self._dataTimeSeries_ax.get_ylim()
+            # Enable the auto scale Y-axis option
+            self.auto_scale_y.setEnabled(True)
             print(f"Preserve zoom enabled. Saved limits: x={self.preserved_xlim}, y={self.preserved_ylim}")
         else:
             # Clear saved limits when checkbox is disabled
             self.preserved_xlim = None
             self.preserved_ylim = None
+            # Disable the auto scale Y-axis option
+            self.auto_scale_y.setEnabled(False)
             print("Preserve zoom disabled. Cleared saved limits.")
         
         # Save GUI state after preserve zoom setting change
@@ -5024,7 +5050,8 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         if self.preserve_axis_zoom.isChecked():
             if self.preserved_xlim is not None:
                 xxlim = self.preserved_xlim
-            if self.preserved_ylim is not None:
+            # Only preserve Y-axis if auto_scale_y is NOT checked
+            if self.preserved_ylim is not None and not self.auto_scale_y.isChecked():
                 yylim = self.preserved_ylim
 
         self._dataTimeSeries_ax.clear()
@@ -5299,11 +5326,14 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                 # Fallback: restore current limits if they're not default
                 self._dataTimeSeries_ax.set_xlim(xxlim)
             
-            if self.preserved_ylim is not None:
-                self._dataTimeSeries_ax.set_ylim(yylim)
-            elif yylim[0] != 0 or yylim[1] != 1:
-                # Fallback: restore current limits if they're not default
-                self._dataTimeSeries_ax.set_ylim(yylim)
+            # Only restore Y limits if auto_scale_y is NOT checked
+            if not self.auto_scale_y.isChecked():
+                if self.preserved_ylim is not None:
+                    self._dataTimeSeries_ax.set_ylim(yylim)
+                elif yylim[0] != 0 or yylim[1] != 1:
+                    # Fallback: restore current limits if they're not default
+                    self._dataTimeSeries_ax.set_ylim(yylim)
+            # If auto_scale_y is checked, don't set ylim - let matplotlib auto-scale
         else:
             # Original behavior - only preserve xlim if not default
             if xxlim[0] != 0 or xxlim[1] != 1:

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -367,10 +367,49 @@ class SnakemakeSetupDialog(QtWidgets.QDialog):
         self.setLayout(layout)
     
     def _browse_snakefile(self):
+        # Try to determine a smart starting directory
+        start_dir = ""
+        
+        # Method 1: If we already have a snakefile path, start in that directory
+        if self.snakefile_edit.text():
+            existing_path = self.snakefile_edit.text()
+            if os.path.exists(existing_path):
+                start_dir = os.path.dirname(existing_path)
+        
+        # Method 2: Try to find workflow folder relative to this script
+        if not start_dir:
+            try:
+                # Get the directory of the current file (time_series_gui.py)
+                # Should be: cedalion-pipeline/workflow/scripts/homer/
+                current_file_dir = os.path.dirname(os.path.abspath(__file__))
+                
+                # Go up two levels to get to workflow folder
+                # ../ -> scripts, ../ -> workflow
+                workflow_dir = os.path.normpath(os.path.join(current_file_dir, '..', '..'))
+                
+                # Verify this is actually a workflow folder by checking for common files
+                if os.path.exists(workflow_dir) and os.path.isdir(workflow_dir):
+                    # Check if directory name is 'workflow' or contains a Snakefile
+                    dir_name = os.path.basename(workflow_dir)
+                    has_snakefile = any(
+                        os.path.exists(os.path.join(workflow_dir, f)) 
+                        for f in ['Snakefile', 'snakefile', 'Snakefile.smk']
+                    )
+                    
+                    if dir_name.lower() == 'workflow' or has_snakefile:
+                        start_dir = workflow_dir
+                        print(f"Auto-detected workflow directory: {start_dir}")
+            except Exception as e:
+                print(f"Could not auto-detect workflow directory: {e}")
+        
+        # Fallback to home directory if no smart start found
+        if not start_dir:
+            start_dir = os.path.expanduser("~")
+        
         file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
             self,
             "Select Snakefile",
-            "",
+            start_dir,
             "Snakefile (Snakefile);;All Files (*)"
         )
         if file_path:
@@ -378,10 +417,45 @@ class SnakemakeSetupDialog(QtWidgets.QDialog):
             self._auto_detect_config(file_path)
     
     def _browse_config(self):
+        # Try to determine a smart starting directory
+        start_dir = ""
+        
+        # Method 1: If we have a snakefile path, look for config folder there
+        snakefile_path = self.snakefile_edit.text()
+        if snakefile_path and os.path.exists(snakefile_path):
+            snakefile_dir = os.path.dirname(snakefile_path)
+            config_dir = os.path.join(snakefile_dir, 'config')
+            if os.path.exists(config_dir) and os.path.isdir(config_dir):
+                start_dir = config_dir
+                print(f"Starting config browser in: {start_dir}")
+        
+        # Method 2: If we already have a config path, start in that directory
+        if not start_dir and self.config_edit.text():
+            existing_path = self.config_edit.text()
+            if os.path.exists(existing_path):
+                start_dir = os.path.dirname(existing_path)
+        
+        # Method 3: Try to find workflow/config folder relative to this script
+        if not start_dir:
+            try:
+                current_file_dir = os.path.dirname(os.path.abspath(__file__))
+                workflow_dir = os.path.normpath(os.path.join(current_file_dir, '..', '..'))
+                config_dir = os.path.join(workflow_dir, 'config')
+                
+                if os.path.exists(config_dir) and os.path.isdir(config_dir):
+                    start_dir = config_dir
+                    print(f"Auto-detected config directory: {start_dir}")
+            except Exception as e:
+                print(f"Could not auto-detect config directory: {e}")
+        
+        # Fallback to home directory if no smart start found
+        if not start_dir:
+            start_dir = os.path.expanduser("~")
+        
         file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
             self,
             "Select Config File",
-            "",
+            start_dir,
             "YAML Files (*.yaml *.yml);;All Files (*)"
         )
         if file_path:
@@ -5213,12 +5287,20 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
 
         # Set axis limits if preserve zoom is enabled or if we have non-default xlim
         if self.preserve_axis_zoom.isChecked():
-            if xxlim[0] != 0 or xxlim[1] != 1:
+            # If we have explicitly preserved limits, always restore them
+            if self.preserved_xlim is not None:
                 self._dataTimeSeries_ax.set_xlim(xxlim)
-            if yylim[0] != 0 or yylim[1] != 1:
+            elif xxlim[0] != 0 or xxlim[1] != 1:
+                # Fallback: restore current limits if they're not default
+                self._dataTimeSeries_ax.set_xlim(xxlim)
+            
+            if self.preserved_ylim is not None:
+                self._dataTimeSeries_ax.set_ylim(yylim)
+            elif yylim[0] != 0 or yylim[1] != 1:
+                # Fallback: restore current limits if they're not default
                 self._dataTimeSeries_ax.set_ylim(yylim)
         else:
-            # Original behavior - only preserve xlim
+            # Original behavior - only preserve xlim if not default
             if xxlim[0] != 0 or xxlim[1] != 1:
                 self._dataTimeSeries_ax.set_xlim(xxlim)
 

--- a/workflow/scripts/homer/time_series_gui.py
+++ b/workflow/scripts/homer/time_series_gui.py
@@ -1805,19 +1805,8 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         self.hrf_view.setEnabled(False)  # Will be enabled when HRF data is available
         hrf_checkbox_layout.addWidget(self.hrf_view)
         
-        # Add HbO checkbox
-        self.hrf_hbo = QtWidgets.QCheckBox("HbO")
-        self.hrf_hbo.setChecked(True)  # Default to HbO selected
-        self.hrf_hbo.stateChanged.connect(self._hrf_chromo_changed)
-        self.hrf_hbo.setEnabled(False)  # Will be enabled when HRF view is active
-        hrf_checkbox_layout.addWidget(self.hrf_hbo)
-        
-        # Add HbR checkbox
-        self.hrf_hbr = QtWidgets.QCheckBox("HbR")
-        self.hrf_hbr.setChecked(False)  # Default to HbR not selected
-        self.hrf_hbr.stateChanged.connect(self._hrf_chromo_changed)
-        self.hrf_hbr.setEnabled(False)  # Will be enabled when HRF view is active
-        hrf_checkbox_layout.addWidget(self.hrf_hbr)
+        # Note: HbO/HbR selection uses the wavelength/chromophore list widget below (wv)
+        # No separate checkboxes needed for HRF view
         
         # Add file type filter for color coding
         hrf_checkbox_layout.addWidget(QtWidgets.QLabel("  |  Color by:"))
@@ -2757,10 +2746,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             if hasattr(self, 'hrf_view'):
                 gui_state['hrf_view'] = bool(self.hrf_view.isChecked())
                 if self.hrf_view.isChecked():
-                    if hasattr(self, 'hrf_hbo'):
-                        gui_state['hrf_hbo'] = bool(self.hrf_hbo.isChecked())
-                    if hasattr(self, 'hrf_hbr'):
-                        gui_state['hrf_hbr'] = bool(self.hrf_hbr.isChecked())
+                    # HbO/HbR selection is handled by wavelength_index (wv widget)
                     if hasattr(self, 'hrf_group_avg'):
                         gui_state['hrf_group_avg'] = bool(self.hrf_group_avg.isChecked())
             
@@ -2998,10 +2984,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
                     self.hrf_view.setChecked(gui_state['hrf_view'])
                     
                     if gui_state['hrf_view']:
-                        if 'hrf_hbo' in gui_state and hasattr(self, 'hrf_hbo'):
-                            self.hrf_hbo.setChecked(gui_state['hrf_hbo'])
-                        if 'hrf_hbr' in gui_state and hasattr(self, 'hrf_hbr'):
-                            self.hrf_hbr.setChecked(gui_state['hrf_hbr'])
+                        # HbO/HbR selection is handled by wavelength_index (wv widget)
                         if 'hrf_group_avg' in gui_state and hasattr(self, 'hrf_group_avg'):
                             self.hrf_group_avg.setChecked(gui_state['hrf_group_avg'])
                         print(f"  Restored HRF view state")
@@ -3836,9 +3819,30 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             if hasattr(self, 'hrf_available_stim_types') and self.hrf_available_stim_types:
                 self.selected_stim_types = set(self.hrf_available_stim_types)
                 self._update_stim_button_text()
-            # Enable chromophore checkboxes
-            self.hrf_hbo.setEnabled(True)
-            self.hrf_hbr.setEnabled(True)
+            
+            # Automatically switch to concentration timeseries to show HbO/HbR
+            # Find a concentration-based timeseries (with chromo dimension)
+            conc_ts_found = False
+            if hasattr(self, 'timeseries_keys'):
+                for ts_name in self.timeseries_keys:
+                    if 'conc' in ts_name.lower():
+                        # Found concentration data, switch to it
+                        self.ts.blockSignals(True)
+                        for i in range(self.ts.count()):
+                            if self.ts.item(i).text() == ts_name:
+                                self.ts.setCurrentRow(i)
+                                conc_ts_found = True
+                                break
+                        self.ts.blockSignals(False)
+                        # Trigger the change manually
+                        if conc_ts_found:
+                            self._ts_changed(ts_name)
+                        break
+            
+            if not conc_ts_found:
+                self.statbar.showMessage("Warning: No concentration data found. HRF view requires concentration timeseries.")
+            
+            # Chromophore selection is handled by wv widget (no separate checkboxes)
             self.launch_plot_probe_btn.setEnabled(True)
             # If group average is checked, disable subject/run dropdowns
             if self.hrf_group_avg.isChecked():
@@ -3848,9 +3852,7 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             # When disabling HRF view, clear all stimulus selections
             self.selected_stim_types = set()
             self._update_stim_button_text()
-            # Disable chromophore checkboxes
-            self.hrf_hbo.setEnabled(False)
-            self.hrf_hbr.setEnabled(False)
+            # Chromophore selection is handled by wv widget (no separate checkboxes)
             self.launch_plot_probe_btn.setEnabled(False)
             # Re-enable subject/run dropdowns
             self.subj.setEnabled(True)
@@ -3882,13 +3884,6 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
             print("Calling _draw_timeseries from _hrf_group_avg_changed")
             self._draw_timeseries()
             # Save GUI state after HRF group average change
-            self._save_gui_state()
-    
-    def _hrf_chromo_changed(self):
-        """Handle changes to HRF chromophore selection"""
-        if self.hrf_view.isChecked():
-            self._draw_timeseries()
-            # Save GUI state after HRF chromophore change
             self._save_gui_state()
     
     def _color_file_type_changed(self):
@@ -5366,12 +5361,17 @@ class _MAIN_GUI(QtWidgets.QMainWindow):
         # Get available chromophores from HRF data
         available_chromos = list(hrf_est.coords['chromo'].values)
         
-        # Filter chromophores based on checkbox selections
+        # Get selected chromophores from wv widget (same as regular time series)
+        wvl_idx = self.wv.selectedItems()
+        wvl_idx = [foo.text() for foo in wvl_idx]
+        
+        # Filter chromophores based on wv selection
         selected_chromos = []
-        if self.hrf_hbo.isChecked() and 'HbO' in available_chromos:
-            selected_chromos.append('HbO')
-        if self.hrf_hbr.isChecked() and 'HbR' in available_chromos:
-            selected_chromos.append('HbR')
+        for sel_wv in wvl_idx:
+            # Remove brackets if present (e.g., "[HbO]" -> "HbO")
+            chromo = sel_wv.strip('[]')
+            if chromo in available_chromos:
+                selected_chromos.append(chromo)
         
         # If no chromophores selected, show message and return
         if not selected_chromos:

--- a/workflow/scripts/image_recon.py
+++ b/workflow/scripts/image_recon.py
@@ -356,7 +356,7 @@ def img_recon_func(cfg_img_recon, cfg_hrf, file_name, Adot_path, out, SB=[], roo
                         save_file_path = os.path.join(save_dir_full, filename )
         
                         print('plotting: ', filename)
-                        image_recon_multi_view(   #FIXME: add off_screen option to this function
+                        image_recon_multi_view(
                             foo_img,  # time series data; can be 2D (static) or 3D (dynamic)
                             head,
                             cmap='jet',
@@ -365,6 +365,7 @@ def img_recon_func(cfg_img_recon, cfg_hrf, file_name, Adot_path, out, SB=[], roo
                             title_str=f'{filename} / uM',
                             filename=save_file_path,
                             SAVE=True,
+                            off_screen=True,
                             #time_range=(foo_img.time.values[0],foo_img.time.values[-1],0.5)*units.s,
                             fps=12,
                             geo3d_plot = None, #  geo3d_plot

--- a/workflow/scripts/image_recon.py
+++ b/workflow/scripts/image_recon.py
@@ -271,106 +271,106 @@ def img_recon_func(cfg_img_recon, cfg_hrf, file_name, Adot_path, out, SB=[], roo
     
     # #%% build and save plots
 
-    # if cfg_img_recon['plot_image']['enable']:
-    #     save_dir_tmp = os.path.join(root_dir, derivatives_subfolder, 'cedalion', 'plots', 'image_recon')
-    #     os.makedirs(save_dir_tmp, exist_ok=True)
+    if cfg_img_recon['plot_image']['enable']:
+        save_dir_tmp = os.path.join(root_dir, derivatives_subfolder, 'cedalion', 'plots', 'image_recon')
+        os.makedirs(save_dir_tmp, exist_ok=True)
 
-    #     folder_name = out.removeprefix("Xs_").removesuffix(".nc")
-    #     suffix = out.split("Xs_")[1].split("_BS")[0]
+        folder_name = out.removeprefix("Xs_").removesuffix(".nc")
+        suffix = out.split("Xs_")[1].split("_BS")[0]
 
-    #     intensity = np.log10(Adot[:,:,0].sum('channel')) # make non-sensitive vertices NaN / gray in image
-    #     mask = intensity > -2
-    #     sensitivity_mask = mask.drop_vars('wavelength')
+        intensity = np.log10(Adot[:,:,0].sum('channel')) # make non-sensitive vertices NaN / gray in image
+        mask = intensity > -2
+        sensitivity_mask = mask.drop_vars('wavelength')
 
-    #     all_trial_X_stderr = np.sqrt(all_trial_X_mse)
-    #     all_trial_X_tstat = all_trial_Xs / all_trial_X_stderr
+        all_trial_X_stderr = np.sqrt(all_trial_X_mse)
+        all_trial_X_tstat = all_trial_Xs / all_trial_X_stderr
 
-    #     all_trial_Xs_plot = all_trial_Xs.where(sensitivity_mask)
-    #     all_trial_X_stderr              = all_trial_X_stderr.where(sensitivity_mask)
-    #     all_trial_X_tstat               = all_trial_X_tstat.where(sensitivity_mask)
+        all_trial_Xs_plot = all_trial_Xs.where(sensitivity_mask)
+        all_trial_X_stderr              = all_trial_X_stderr.where(sensitivity_mask)
+        all_trial_X_tstat               = all_trial_X_tstat.where(sensitivity_mask)
 
-    #     plot_img = cfg_img_recon['plot_image']
+        plot_img = cfg_img_recon['plot_image']
 
-    #     flag_hbo_list = plot_img['flag_hbo_list']  
-    #     flag_brain_list = plot_img['flag_brain_list']
-    #     flag_img_list = plot_img['flag_img_list'] 
+        flag_hbo_list = plot_img['flag_hbo_list']  
+        flag_brain_list = plot_img['flag_brain_list']
+        flag_img_list = plot_img['flag_img_list'] 
             
-    #     flag_condition_list = cfg_hrf['stim_lst']
+        flag_condition_list = cfg_hrf['stim_lst']
         
-    #     for flag_hbo in flag_hbo_list:
+        for flag_hbo in flag_hbo_list:
             
-    #         for flag_brain in flag_brain_list: 
+            for flag_brain in flag_brain_list: 
                 
-    #             for flag_condition in flag_condition_list:
+                for flag_condition in flag_condition_list:
                     
-    #                 for flag_img in flag_img_list:
+                    for flag_img in flag_img_list:
                         
-    #                     if flag_hbo in ['hbo', 'HbO']:
-    #                         title_str = flag_condition + ' ' + 'HbO'
-    #                         hbx_brain_scalp = 'hbo'
-    #                     else:
-    #                         title_str = flag_condition + ' ' + 'HbR'
-    #                         hbx_brain_scalp = 'hbr'
+                        if flag_hbo in ['hbo', 'HbO']:
+                            title_str = flag_condition + ' ' + 'HbO'
+                            hbx_brain_scalp = 'hbo'
+                        else:
+                            title_str = flag_condition + ' ' + 'HbR'
+                            hbx_brain_scalp = 'hbr'
                         
-    #                     if flag_brain in ['brain', 'Brain']:
-    #                         title_str = title_str + ' brain'
-    #                         hbx_brain_scalp = hbx_brain_scalp + '_brain'
-    #                     else:
-    #                         title_str = title_str + ' scalp'
-    #                         hbx_brain_scalp = hbx_brain_scalp + '_scalp'
+                        if flag_brain in ['brain', 'Brain']:
+                            title_str = title_str + ' brain'
+                            hbx_brain_scalp = hbx_brain_scalp + '_brain'
+                        else:
+                            title_str = title_str + ' scalp'
+                            hbx_brain_scalp = hbx_brain_scalp + '_scalp'
                         
-    #                     if len(flag_condition_list) > 1:
-    #                         if flag_img == 'tstat':
-    #                             foo_img = all_trial_X_tstat.sel(trial_type=flag_condition).copy()
-    #                             title_str = title_str + ' t-stat'
-    #                         elif flag_img == 'mag':
-    #                             foo_img = all_trial_Xs_plot.sel(trial_type=flag_condition).copy()
-    #                             title_str = title_str + ' magnitude'
-    #                         elif flag_img == 'noise':
-    #                             foo_img = all_trial_X_stderr.sel(trial_type=flag_condition).copy()
-    #                             title_str = title_str + ' noise'
-    #                     else:
-    #                         if flag_img == 'tstat':
-    #                             foo_img = all_trial_X_tstat.copy()
-    #                             title_str = title_str + ' t-stat'
-    #                         elif flag_img == 'mag':
-    #                             foo_img = all_trial_Xs_plot.copy()
-    #                             title_str = title_str + ' magnitude'
-    #                         elif flag_img == 'noise':
-    #                             foo_img = all_trial_X_stderr.copy()
-    #                             title_str = title_str + ' noise'
+                        if len(flag_condition_list) > 1:
+                            if flag_img == 'tstat':
+                                foo_img = all_trial_X_tstat.sel(trial_type=flag_condition).copy()
+                                title_str = title_str + ' t-stat'
+                            elif flag_img == 'mag':
+                                foo_img = all_trial_Xs_plot.sel(trial_type=flag_condition).copy()
+                                title_str = title_str + ' magnitude'
+                            elif flag_img == 'noise':
+                                foo_img = all_trial_X_stderr.sel(trial_type=flag_condition).copy()
+                                title_str = title_str + ' noise'
+                        else:
+                            if flag_img == 'tstat':
+                                foo_img = all_trial_X_tstat.copy()
+                                title_str = title_str + ' t-stat'
+                            elif flag_img == 'mag':
+                                foo_img = all_trial_Xs_plot.copy()
+                                title_str = title_str + ' magnitude'
+                            elif flag_img == 'noise':
+                                foo_img = all_trial_X_stderr.copy()
+                                title_str = title_str + ' noise'
                 
-    #                     if 'reltime' in foo_img.dims:
-    #                         foo_img = foo_img.rename({"reltime": "time"})
-    #                         foo_img = foo_img.transpose("vertex", "chromo", "time")
-    #                     clim = (-foo_img.sel(chromo='HbO').max(), foo_img.sel(chromo='HbO').max())
+                        if 'reltime' in foo_img.dims:
+                            foo_img = foo_img.rename({"reltime": "time"})
+                            foo_img = foo_img.transpose("vertex", "chromo", "time")
+                        clim = (-foo_img.sel(chromo='HbO').max(), foo_img.sel(chromo='HbO').max())
 
-    #                     filename = f'IMG_{flag_condition}_{flag_img}_{hbx_brain_scalp}'
-    #                     # create overall folder for current image recon params 
-    #                     save_dir_tmp_ful = os.path.join(save_dir_tmp, folder_name)
-    #                     os.makedirs(save_dir_tmp_ful, exist_ok=True) 
+                        filename = f'IMG_{flag_condition}_{flag_img}_{hbx_brain_scalp}'
+                        # create overall folder for current image recon params 
+                        save_dir_tmp_ful = os.path.join(save_dir_tmp, folder_name)
+                        os.makedirs(save_dir_tmp_ful, exist_ok=True) 
 
 
-    #                     save_dir_full = os.path.join(save_dir_tmp_ful, suffix)
-    #                     os.makedirs(save_dir_full, exist_ok=True)
-    #                     save_file_path = os.path.join(save_dir_full, filename )
+                        save_dir_full = os.path.join(save_dir_tmp_ful, suffix)
+                        os.makedirs(save_dir_full, exist_ok=True)
+                        save_file_path = os.path.join(save_dir_full, filename )
         
-    #                     print('plotting: ', filename)
-    #                     image_recon_multi_view(   #FIXME: add off_screen option to this function
-    #                         foo_img,  # time series data; can be 2D (static) or 3D (dynamic)
-    #                         head,
-    #                         cmap='jet',
-    #                         clim=clim,
-    #                         view_type=hbx_brain_scalp,
-    #                         title_str=f'{filename} / uM',
-    #                         filename=save_file_path,
-    #                         SAVE=True,
-    #                         #time_range=(foo_img.time.values[0],foo_img.time.values[-1],0.5)*units.s,
-    #                         fps=12,
-    #                         geo3d_plot = None, #  geo3d_plot
-    #                         wdw_size = (1024, 768)
-    #                     )
-    #                  #              
+                        print('plotting: ', filename)
+                        image_recon_multi_view(   #FIXME: add off_screen option to this function
+                            foo_img,  # time series data; can be 2D (static) or 3D (dynamic)
+                            head,
+                            cmap='jet',
+                            clim=clim,
+                            view_type=hbx_brain_scalp,
+                            title_str=f'{filename} / uM',
+                            filename=save_file_path,
+                            SAVE=True,
+                            #time_range=(foo_img.time.values[0],foo_img.time.values[-1],0.5)*units.s,
+                            fps=12,
+                            geo3d_plot = None, #  geo3d_plot
+                            wdw_size = (1024, 768)
+                        )
+                     #              
                      
     
 

--- a/workflow/scripts/modules/module_plot_DQR.py
+++ b/workflow/scripts/modules/module_plot_DQR.py
@@ -440,6 +440,23 @@ def plot_slope(rec = None, slope = None, cfg_preprocess=None, filenm = None, roo
     
 
 def plotDQR_sidecar(file_json, rec, root_dir, derivatives_subfolder, filenm):
+    # These fields are optional, device-specific calibration metadata and are
+    # not part of a minimal BIDS NIRS sidecar. Skip these extra plots when the
+    # acquisition did not provide them; the standard DQR remains available.
+    required_fields = {
+        'dataSDWP_LowHigh',
+        'powerLevelSetting',
+        'powerLevelSetLowHigh',
+        'srcModuleGroups',
+        'SD',
+    }
+    missing_fields = sorted(required_fields.difference(file_json))
+    if missing_fields:
+        print(
+            "Skipping optional DQR sidecar plots; missing JSON fields: "
+            + ", ".join(missing_fields)
+        )
+        return
 
     # get the variables from the json file
     dataSDWP_LowHigh = file_json['dataSDWP_LowHigh']


### PR DESCRIPTION
This PR fixes several Windows-specific issues encountered when running the HomerPy/Snakemake pipeline from the GUI.

### Changes

- Resolve the actual Conda executable path on Windows, including `conda.bat`, instead of relying on the shell-specific `conda` command.
- Use `conda run` consistently when launching Snakemake from the GUI.
- Add `--drop-metadata` on Windows to avoid Snakemake metadata filename-length failures.
- Fix the summary warning dialog so clicking “Yes” correctly continues the pipeline.
- Skip optional DQR sidecar plots when device-specific JSON fields are missing, while keeping the standard DQR output.

### Why

The pipeline worked from a terminal but failed from the GUI because the GUI process could not resolve Conda the same way an activated terminal can. On Windows, Conda is often exposed through `conda.bat`, and Python subprocess calls need the actual executable path.

